### PR TITLE
Fix mouse down behaviour of Format Toolbar

### DIFF
--- a/src/components/EditorFormatTextToolbar.js
+++ b/src/components/EditorFormatTextToolbar.js
@@ -174,6 +174,7 @@ class FormatTextToolbar extends React.Component {
           ref, style, placementA, arrowProps
         }) => (
           <div
+            id="format-toolbar"
             ref={ref}
             style={{ ...style, zIndex: 100 }}
             data-placement={placementA}

--- a/src/components/FreeEditor.js
+++ b/src/components/FreeEditor.js
@@ -129,12 +129,21 @@ export class FreeEditor extends React.Component {
     }
   }
 
+  /* eslint-disable-next-line */
   onMouseDown(e) {
-    // Do nothing if click origin is not from content area
-    if (e.target.dataset.slateContent !== 'true') {
-      e.preventDefault();
-      return;
-    }
+    // The following block verifies if the event is coming from the toolbar
+    // by checking if toolbar container (#format-toolbar) is a parent element
+    // of target node. If so, it executes e.preventsDefault() to avoid losing
+    // focus of selected text.
+    const toolbar = document.querySelector('#format-toolbar');
+    let el = e.target;
+    do {
+      if (el && el === toolbar) {
+        e.preventDefault();
+        return;
+      }
+      el = el.parentNode;
+    } while (el && el.tagName !== 'BODY' && el.tagName !== 'HTML');
 
     const { activeTool } = this.state;
     if (activeTool) {


### PR DESCRIPTION
The PR https://github.com/developmentseed/nasa-apt-frontend/pull/19 introduced an error with modal forms, making them unfocusable. This was caused by `e.preventDefault()` being executed in situations not related to the formatting toolbar. This PR adds a change to `onMouseDown` to better identify if the toolbar was the origin of the event, avoiding side-effects in modal components.

This approach was suggested by @danielfdsilva and used at the Dropdown component:

https://github.com/developmentseed/nasa-apt-frontend/blob/develop/src/components/common/Dropdown.js#L19-L30