### PR TITLE
Rename labels for list features

### DIFF
--- a/src/components/FreeEditor.js
+++ b/src/components/FreeEditor.js
@@ -649,7 +649,7 @@ export class FreeEditor extends React.Component {
                 onClick={this.insertUnorderedList}
                 disabled={!hasCursor}
               >
-                Unordered list
+                Bullets
               </ULBtn>
 
               <OLBtn
@@ -658,7 +658,7 @@ export class FreeEditor extends React.Component {
                 onClick={this.insertOrderedList}
                 disabled={!hasCursor}
               >
-                Ordered list
+                List
               </OLBtn>
 
               {inlineSaveBtn && (


### PR DESCRIPTION
`Unordered list` and `Ordered list` are a bit long/technical for the header menu. Let's replace these labels with `Bullets` and `List`.