### PR TITLE
Fix url editor

### DIFF
--- a/src/components/common/slateEditor/LinkToolbar.js
+++ b/src/components/common/slateEditor/LinkToolbar.js
@@ -99,7 +99,7 @@ export default class LinkEditorToolbar extends React.Component {
     );
 
     if (!this.blockNextOutsideClick && this.urlEditorRef.current && !isInside) {
-      onCancel();
+      onCancel({ reason: 'dismiss-outside' });
     }
     this.blockNextOutsideClick = false;
   }
@@ -135,7 +135,7 @@ export default class LinkEditorToolbar extends React.Component {
     // esc
     if (keyCode === 27) {
       e.preventDefault();
-      onCancel();
+      onCancel({ reason: 'dismiss-esc' });
       this.setState({ urlValue: '' });
     }
   }


### PR DESCRIPTION
Editing the url was not working if performed before focusing the slate editor.

Steps to reproduce (at least on firefox):
- open http://localhost:3006/atbdsedit/11/drafts/1/introduction
- Without clicking anywhere else, click on one of the links
- change the url and press <enter>
- click again the same link - the value was not updated

This PR fixes the above bug using a better slate api.