### PR TITLE
Disable edit for Published ATBDS and add duplicate button

### DIFF
--- a/src/assets/icons/collecticons/pages.svg
+++ b/src/assets/icons/collecticons/pages.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" id="icon-bound" fill="none" />
+  <path d="M3,3H1v13h11v-2H3V3z M12,0H4v13h11V3L12,0z M13,11H6V2h5v2h2V11z" />
+</svg>

--- a/src/components/atbds/index.js
+++ b/src/components/atbds/index.js
@@ -143,6 +143,12 @@ const DocTableActionPublish = styled(DropMenuItem)`
   }
 `;
 
+const DocTableActionDuplicate = styled(DropMenuItem)`
+  &::before {
+    ${collecticon('pages')}
+  }
+`;
+
 const DocTableActionDelete = styled(DropMenuItem)`
   &::before {
     ${collecticon('trash-bin')}
@@ -303,7 +309,7 @@ class AtbdList extends React.Component {
               >
                 Actions
               </DocTableActionsTrigger>
-)}
+            )}
           >
             <DropTitle>Document actions</DropTitle>
             <DropMenu role="menu" iconified>
@@ -316,24 +322,36 @@ class AtbdList extends React.Component {
                   View
                 </DocTableActionView>
               </li>
-              <li>
-                <DocTableActionEdit
-                  title="Edit document"
-                  as={Link}
-                  to={`/${atbdsedit}/${atbd_id}/${drafts}/1/${identifying_information}`}
-                >
-                  Edit
-                </DocTableActionEdit>
-              </li>
-              {status === 'Draft' && (
+              {status === 'Draft' ? (
+                <React.Fragment>
+                  <li>
+                    <DocTableActionEdit
+                      title="Edit document"
+                      as={Link}
+                      to={`/${atbdsedit}/${atbd_id}/${drafts}/1/${identifying_information}`}
+                    >
+                      Edit
+                    </DocTableActionEdit>
+                  </li>
+                  <li>
+                    <DocTableActionPublish
+                      title="Publish document"
+                      data-hook="dropdown:close"
+                      onClick={this.onUpdateClick.bind(this, atbd)}
+                    >
+                      Publish
+                    </DocTableActionPublish>
+                  </li>
+                </React.Fragment>
+              ) : (
                 <li>
-                  <DocTableActionPublish
-                    title="Publish document"
+                  <DocTableActionDuplicate
+                    title="Duplicate document"
                     data-hook="dropdown:close"
-                    onClick={this.onUpdateClick.bind(this, atbd)}
+                    onClick={() => alert('Implementation pending')}
                   >
-                    Publish
-                  </DocTableActionPublish>
+                    Duplicate
+                  </DocTableActionDuplicate>
                 </li>
               )}
             </DropMenu>

--- a/src/store/locationMiddleware.js
+++ b/src/store/locationMiddleware.js
@@ -16,6 +16,7 @@ import {
   references,
   error
 } from '../constants/routes';
+import toasts from '../components/common/toasts';
 
 const locationMiddleware = store => next => async (action) => {
   const { type, payload } = action;
@@ -105,6 +106,16 @@ const locationMiddleware = store => next => async (action) => {
     const { atbd_id, atbd_version } = created_version;
     store.dispatch(push(`/${atbdsedit}/${atbd_id}/${drafts}/${atbd_version}/`
       + `${identifying_information}`));
+  }
+
+  // After fetching the version, if we're on the edit page and the ATBD
+  // was already published redirect with a notification.
+  if (type === types.FETCH_ATBD_VERSION_SUCCESS) {
+    const pieces = store.getState().router.location.pathname.split('/');
+    if (pieces[1] === atbdsedit && payload.status === 'Published') {
+      toasts.error('Editing a Published ATBD is not allowed. Consider making a copy.');
+      store.dispatch(push(`/${atbds}`));
+    }
   }
   return next(action);
 };


### PR DESCRIPTION
- Edit button removed from `Published` atbd on list view menu. Duplicate button was added (just displays an alert at the moment).
![image](https://user-images.githubusercontent.com/1090606/65679430-f986ad00-e04c-11e9-8960-91b963862674.png)

- Enabled options menu for atbs view page, removed Edit button when atbd is `Published`.
![image](https://user-images.githubusercontent.com/1090606/65679519-2b980f00-e04d-11e9-8fe3-bab0f57432bd.png)

- Disabled edit route for `Published` atbds. If accessed, the user is redirected to the atbd list with a toast message.
<img width="464" alt="image" src="https://user-images.githubusercontent.com/1090606/65679664-6e59e700-e04d-11e9-9404-3c5278f03080.png">
