### PR TITLE
Replace Equation Editor default code with valid LaTeX.

### DIFF
--- a/src/components/FreeEditor.js
+++ b/src/components/FreeEditor.js
@@ -284,7 +284,7 @@ export class FreeEditor extends React.Component {
             object: 'text',
             leaves: [
               {
-                text: '\\'
+                text: '\\LaTeX~equation'
               }
             ]
           }


### PR DESCRIPTION
### Context

Click on the Equation toolbar button in the editor. Instead of a parse error, you should be prompted to enter LaTeX code.

<img width="1161" alt="Screen Shot 2020-05-06 at 4 11 00 PM" src="https://user-images.githubusercontent.com/766758/81233683-6a634f80-8fb4-11ea-92a7-e0e21f27b4b1.png">

<img width="1160" alt="Screen Shot 2020-05-06 at 4 11 38 PM" src="https://user-images.githubusercontent.com/766758/81233710-79e29880-8fb4-11ea-929f-d959ccfc7916.png">

### Actions
- Replace Equation Editor default code with valid LaTeX.
- This also provides a hint to the user what's happening.

Fixes https://github.com/developmentseed/nasa-apt/issues/14