### PR TITLE
Allow multiple help pages

### DIFF
--- a/help-documentation/help.md
+++ b/help-documentation/help.md
@@ -1,3 +1,6 @@
+---
+title: ATBD creation
+---
 # User Guide for Authoring ATBDs using the Algorithm Publication Tool (APT)
 
 ## 1. Introduction

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",
-    "markdown-it": "^10.0.0",
     "object-path": "^0.11.4",
     "polished": "^2.3.3",
     "prop-types": "^15.7.2",
@@ -99,10 +98,12 @@
     "eslint-plugin-react": "^7.12.4",
     "fs-extra": "^9.0.0",
     "js-yaml": "^3.13.1",
+    "markdown-it": "^10.0.0",
     "proxyquire": "^2.1.0",
     "sinon": "^7.2.4",
     "surge": "^0.21.3",
     "tape": "^4.10.1",
-    "watch": "^1.0.2"
+    "watch": "^1.0.2",
+    "yaml-front-matter": "^4.1.0"
   }
 }

--- a/process-help.js
+++ b/process-help.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 const MarkdownIt = require('markdown-it');
+const yamlFront = require('yaml-front-matter');
 
 const mdRenderer = new MarkdownIt({ html: true });
 
@@ -24,13 +25,15 @@ async function main() {
 
     try {
       const mdContent = fs.readFileSync(path.join(docs, f), 'utf8');
-      const rendered = mdRenderer.render(mdContent);
+      const data = yamlFront.loadFront(mdContent);
+      const rendered = mdRenderer.render(data.__content);
       fs.writeFileSync(
         path.join(__dirname, `public/docs/${id}.json`),
-        JSON.stringify({ content: rendered })
+        JSON.stringify({ title: data.title, content: rendered })
       );
       pageIndex.push({
         id,
+        title: data.title,
         url: `/docs/${id}.json`,
       });
     } catch (e) {

--- a/src/components/common/Dropdown.js
+++ b/src/components/common/Dropdown.js
@@ -493,7 +493,8 @@ export const DropMenuItem = styled.a`
     opacity: 1;
   }
 
-  ${({ active }) => active && css`
+  ${({ active }) => active ? '&, &:visited,' : ''}
+  &.active, &.active:visited {
     color: inherit;
 
     &::after {
@@ -508,7 +509,7 @@ export const DropMenuItem = styled.a`
       width: 1.5rem;
       text-align: center;
     }
-  `}
+  }
 `;
 
 export const DropInset = styled.div`

--- a/src/components/help/index.js
+++ b/src/components/help/index.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
+import { NavLink } from 'react-router-dom';
 import { push } from 'connected-react-router';
+import { rgba } from 'polished';
 
 import {
   Inpage,
@@ -11,10 +13,17 @@ import {
   InpageHeadline,
   InpageTitle,
   InpageBody,
-  InpageBodyInner
+  InpageBodyInner,
+  InpageToolbar
 } from '../common/Inpage';
 import Prose from '../../styles/type/prose';
+import Button from '../../styles/button/button';
 import { showGlobalLoading, hideGlobalLoading } from '../common/OverlayLoader';
+import Dropdown, { DropMenu, DropTitle, DropMenuItem } from '../common/Dropdown';
+import { headingAlt } from '../../styles/type/heading';
+import { stylizeFunction } from '../../styles/utils/general';
+
+const _rgba = stylizeFunction(rgba);
 
 const HelpProse = styled(Prose)`
   max-width: 50rem;
@@ -28,6 +37,30 @@ const HelpProse = styled(Prose)`
     margin: 0 auto;
     font-style: italic;
   }
+`;
+
+
+const StepDrop = styled(Dropdown)`
+  min-width: 20rem;
+`;
+
+const Stepper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  line-height: 2.5rem;
+  align-items: center;
+
+  > * {
+    display: inline-flex;
+  }
+`;
+
+const StepperLabel = styled.h6`
+  ${headingAlt()}
+  font-size: 0.875rem;
+  color: ${_rgba('#FFFFFF', 0.64)};
+  margin-right: 0.5rem;
+  white-space: nowrap;
 `;
 
 class Help extends Component {
@@ -89,6 +122,51 @@ class Help extends Component {
     }
   }
 
+  renderNavigation() {
+    const { pagesIndex } = this.state;
+    if (!pagesIndex) return null;
+
+    // Default to help if no id is provided.
+    const pageId = this.props.match.params.page_id || 'help';
+
+    const page = pagesIndex.find(p => p.id === pageId);
+    if (!page) return null;
+
+    return (
+      <Stepper>
+        <StepperLabel>Sections</StepperLabel>
+        <StepDrop
+          alignment="right"
+          triggerElement={(
+            <Button
+              variation="achromic-plain"
+              title="Toggle help sections"
+              useIcon={['chevron-down--small', 'after']}
+            >
+              {page.title}
+            </Button>
+          )}
+        >
+          <DropTitle>Select section</DropTitle>
+          <DropMenu role="menu" selectable>
+            {pagesIndex.map(p => (
+              <li key={p.id}>
+                <DropMenuItem
+                  exact
+                  as={NavLink}
+                  to={p.id === 'help' ? '/help' : `/help/${p.id}`}
+                  data-hook="dropdown:close"
+                >
+                  {p.title}
+                </DropMenuItem>
+              </li>
+            ))}
+          </DropMenu>
+        </StepDrop>
+      </Stepper>
+    );
+  }
+
   render() {
     return (
       <Inpage>
@@ -97,6 +175,9 @@ class Help extends Component {
             <InpageHeadline>
               <InpageTitle>Help center for APT</InpageTitle>
             </InpageHeadline>
+            <InpageToolbar>
+              {this.renderNavigation()}
+            </InpageToolbar>
           </InpageHeaderInner>
         </InpageHeader>
         <InpageBody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,6 +2992,11 @@ commander@^2.11.0, commander@^2.12.2, commander@^2.19.0, commander@^2.20.0, comm
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^2.14.1:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
@@ -6720,6 +6725,14 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
+
+js-yaml@^3.10.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
@@ -12440,6 +12453,14 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+
+yaml-front-matter@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/yaml-front-matter/-/yaml-front-matter-4.1.0.tgz#218da823c2539901a441a041fcf7092c48ec1595"
+  integrity sha512-E2NKXUe8Amsf3kyLDK48c2gvnfom0Yj3m7455iVVg+G5UbX66V5iqFSpEUkQ+A3iJCKIz+mvAbkN7BQ+N0wiLA==
+  dependencies:
+    commander "^2.14.1"
+    js-yaml "^3.10.0"
 
 yargs-parser@^10.1.0:
   version "10.1.0"


### PR DESCRIPTION
Add navigation between different help pages.

Help documents must have a front matter with a title property that is displayed in the dropdown navigation.