### PR TITLE
Pin katex version to 0.12.0 using `resolutions` item in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "immutable": "^4.0.0-rc.12",
     "is-url": "^1.2.4",
     "jsonschema": "^1.2.4",
+    "katex": "^0.12.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.deburr": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7210,7 +7210,7 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
   integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
-katex@0.12.0, katex@^0.9.0:
+katex@0.12.0, katex@^0.12.0, katex@^0.9.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.12.0.tgz#2fb1c665dbd2b043edcf8a1f5c555f46beaa0cb9"
   integrity sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==


### PR DESCRIPTION
# What I did: 
Pinned katex version to `0.12.0` 

# Why I did it: 
I needed the linebreak (`\\`) feature in order to be able to break long equations into multiple lines. This feature was released in katex [version 0.10.0](https://github.com/KaTeX/KaTeX/pull/1298). While the `react-katex` npm package specifies [^0.9.0](https://github.com/talyssonoc/react-katex/blob/3ae5cbdc7871f408b59d6a39aa41f53c0938ada3/package.json#L67) for the Katex dependency, `katex@0.9.0` was consistently being installed (as opposed to the more recent versions) when using `yarn add react-katex`. 

# How I did it: 
I added the following line to the `resolutions` item of `package.json`: 
```
"**/katex": "0.12.0"
```
to ensure that any katex sub-dependency get installed at the most recent version

# How you can test it: 
Run the front-end locally and create a new equation using the `\\` symbol. Notice that before, where the equation would give you an error message (`KaTeX parse error: Expected 'EOF', got '\\' at position ...` ) now the equation will display on 2 (or more lines)

![image](https://user-images.githubusercontent.com/11858457/101930744-8c562d80-3ba6-11eb-8b82-6279d8586f9f.png)

In order to ensure that the equation gets correctly aligned (if on multiple lines) wrap the equation with 
```
\begin{aligned} ... \end{aligned}
```
insert `\\` where line breaks should occur, and insert the `&` character at the desired "anchor" position.

### Eg:
```
\begin{aligned} x &= mx^2 + bx +c \\ 2y + ab & = mx + b \end{aligned}
```
results in: 
```
      x = mx^2 + bx + c
2y + ab = mb + b
``` 
(with both equations aligned on the `=` symbol). Without the `&` anchor the equation would look like: 
```
x = mx^2 + bx + c
2y + ab = mb + b
```
