### PR TITLE
Remove outdated contact information on the about page

### DIFF
--- a/src/components/about/index.js
+++ b/src/components/about/index.js
@@ -35,7 +35,6 @@ class About extends Component {
                 This is the <strong>Algorithm Publication Tool</strong> prototype.<br />
                 We have endeavored to make it as easy as possible to create new ATBDs, and welcome all feedback.
               </p>
-              <p>Please feel free to <a href="mailto:alyssa@developmentseed.org?Subject=APT Prototype Feedback" target="_top">send us an e-mail</a>.</p>
             </AboutProse>
           </InpageBodyInner>
         </InpageBody>


### PR DESCRIPTION
In the future, this will be replaced by the Feedback module.