### PR TITLE
Makes PageHeader sticky

### DIFF
--- a/app/assets/scripts/components/common/page-header.js
+++ b/app/assets/scripts/components/common/page-header.js
@@ -29,7 +29,8 @@ import UserImage from './user-image';
 const { appTitle } = config;
 
 const PageHeaderSelf = styled.header`
-  position: relative;
+  position: sticky;
+  top: 0;
   z-index: 10;
   display: grid;
   grid-template-columns: max-content 1fr;

--- a/app/assets/scripts/styles/inpage.js
+++ b/app/assets/scripts/styles/inpage.js
@@ -45,8 +45,13 @@ export const InpageHeader = styled.header.attrs({
 
 export const InpageHeaderSticky = styled(InpageHeader)`
   position: sticky;
-  top: 0;
   z-index: 7000;
+
+  top: calc(40px + 0.75rem * 2);
+
+  ${media.mediumUp`
+    top: calc(40px + 1rem * 2);
+  `}
 `;
 
 export const InpageHeadline = styled.div`


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/472; addressing "Once users have found their information, users are able to quickly navigate to somewhere else in the app"

I figured the most straightforward way to deal with this is to make the page header sticky and ensure that the in-page header always sits below the page header. 

<img width="1525" alt="Screenshot 2022-03-23 at 11 59 20" src="https://user-images.githubusercontent.com/159510/159694596-bece5d82-d896-4803-921d-624b14fbcc35.png">

The only drawback is that this affects the whole app, so we're losing a bit of screen real estate everywhere but I feel this is an ok compromise. 

cc: @aboydnw 