### PR TITLE
Login improvements

### DIFF
--- a/app/assets/scripts/components/dashboard/index.js
+++ b/app/assets/scripts/components/dashboard/index.js
@@ -159,10 +159,18 @@ function UserDashboard() {
               <WelcomeBlockProse>
                 <p>Here&apos;s what is happening in your APT account today.</p>
                 {!conAccessContributorDash && !conAccessCuratorDash && (
-                  <p>
-                    Your account has not yet been approved. You can only access{' '}
-                    <strong>published</strong> documents.
-                  </p>
+                  <>
+                    <p>
+                      Your account is not yet approved by an APT Administrator,
+                      this action can take up to 1 business day. If you have not
+                      been approved after this time, please send a message via
+                      the feedback button with your name, email and the day/time
+                      you signed up.
+                    </p>
+                    <p>
+                      You can still access <strong>published</strong> documents.
+                    </p>
+                  </>
                 )}
               </WelcomeBlockProse>
             </WelcomeBlock>

--- a/app/assets/scripts/context/user.js
+++ b/app/assets/scripts/context/user.js
@@ -26,7 +26,7 @@ import { CONTRIBUTOR_ROLE, CURATOR_ROLE } from '../a11n/rules';
 // https://example.com/#id_token=123&access_token=abc&expires_in=3600&token_type=Bearer
 // localstack does:
 // https://example.com/?id_token=123#id_token=123
-export function hackyAmplifyTokenInit() {
+export function initAuthFromUrlParams() {
   const decodePayload = (jwtToken) => {
     const payload = jwtToken.split('.')[1];
     return JSON.parse(atob(payload));

--- a/app/assets/scripts/context/user.js
+++ b/app/assets/scripts/context/user.js
@@ -7,11 +7,67 @@ import React, {
 } from 'react';
 import T from 'prop-types';
 import Amplify, { Auth } from 'aws-amplify';
+import qs from 'qs';
 
 import { useContextualAbility, updateAbilityFor } from '../a11n';
 import config from '../config';
 import { createContextChecker } from '../utils/create-context-checker';
 import { CONTRIBUTOR_ROLE, CURATOR_ROLE } from '../a11n/rules';
+
+// If the user logs in through the cognito hosted UI, the user is then
+// redirected to the apt homepage with the token appended in the url.
+// Unfortunately Amplify is not able to pick it up, nor there's a way to
+// initialize Amplify Auth with a preexisting token. The solution is a hacky
+// approach where we set the token directly in the localstorage so that Amplify
+// will pick it up when booting.
+// The following issue explains the problem and the "solution": https://github.com/aws-amplify/amplify-js/issues/825#issuecomment-496977827
+// Note that this doesn't work with localstack because it redirects the user
+// back to the homepage with the wrong values in the url - instead of being:
+// https://example.com/#id_token=123&access_token=abc&expires_in=3600&token_type=Bearer
+// localstack does:
+// https://example.com/?id_token=123#id_token=123
+export function hackyAmplifyTokenInit() {
+  const decodePayload = (jwtToken) => {
+    const payload = jwtToken.split('.')[1];
+    return JSON.parse(atob(payload));
+  };
+
+  const calculateClockDrift = (iatAccessToken, iatIdToken) => {
+    const now = Math.floor(new Date() / 1000);
+    const iat = Math.min(iatAccessToken, iatIdToken);
+    return now - iat;
+  };
+
+  const locHash = location.hash.substring(1);
+  const { id_token, access_token } = qs.parse(locHash);
+  if (id_token && access_token) {
+    try {
+      const clientId = config.auth.userPoolWebClientId;
+      const idTokenData = decodePayload(id_token);
+      const accessTokenData = decodePayload(access_token);
+      const username = idTokenData['cognito:username'];
+
+      localStorage.setItem(
+        `CognitoIdentityServiceProvider.${clientId}.LastAuthUser`,
+        username
+      );
+      localStorage.setItem(
+        `CognitoIdentityServiceProvider.${clientId}.${username}.idToken`,
+        id_token
+      );
+      localStorage.setItem(
+        `CognitoIdentityServiceProvider.${clientId}.${username}.accessToken`,
+        access_token
+      );
+      localStorage.setItem(
+        `CognitoIdentityServiceProvider.${clientId}.${username}.clockDrift`,
+        calculateClockDrift(accessTokenData.iat, idTokenData.iat).toString()
+      );
+    } catch (error) {
+      // Something went wrong. User will not be authenticated.
+    }
+  }
+}
 
 Amplify.configure(config.auth);
 

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -41,7 +41,7 @@ import Authorize from './a11n/authorize';
 // Contexts
 import { AtbdsProvider } from './context/atbds-list';
 import { ContactsProvider } from './context/contacts-list';
-import { hackyAmplifyTokenInit, UserProvider } from './context/user';
+import { initAuthFromUrlParams, UserProvider } from './context/user';
 import { JsonPagesProvider } from './context/json-pages';
 import { SearchProvider } from './context/search';
 import { AbilityProvider } from './a11n/index';
@@ -50,7 +50,7 @@ import { CollaboratorsProvider } from './context/collaborators-list';
 import { ThreadsProvider } from './context/threads-list';
 
 // See note on context/user.js
-hackyAmplifyTokenInit();
+initAuthFromUrlParams();
 
 const composingComponents = [
   ErrorBoundary,

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -41,13 +41,16 @@ import Authorize from './a11n/authorize';
 // Contexts
 import { AtbdsProvider } from './context/atbds-list';
 import { ContactsProvider } from './context/contacts-list';
-import { UserProvider } from './context/user';
+import { hackyAmplifyTokenInit, UserProvider } from './context/user';
 import { JsonPagesProvider } from './context/json-pages';
 import { SearchProvider } from './context/search';
 import { AbilityProvider } from './a11n/index';
 import { CommentCenterProvider } from './context/comment-center';
 import { CollaboratorsProvider } from './context/collaborators-list';
 import { ThreadsProvider } from './context/threads-list';
+
+// See note on context/user.js
+hackyAmplifyTokenInit();
 
 const composingComponents = [
   ErrorBoundary,


### PR DESCRIPTION
Contribute to https://github.com/NASA-IMPACT/nasa-apt/issues/469

This PR adds the ability for the user to be logged in automatically once redirected from the hosted cofnito UI.

The library we're using to handle the congito comunication in the frontend ([AWS Amplify](https://aws.amazon.com/amplify/authentication)) does not support being initialized with a token.
If it manages the whole process (login with user and pwd) then it works fine - this is the normal flow we have implemented.
If, on the other hand, cognito UI handles the login then Amplify will not pick up on the token. This is why the user was not logged in.

After quite some digging I found an issue that talked about this [exact problem](https://github.com/aws-amplify/amplify-js/issues/825#issuecomment-496977827) and provided a solution, albeit hacky.
The solution works and I was able to initialize the Amplify session from the provided token.

However this does not work when running localstack (our local aws instance) because it returns the wrong token format in the url.
✅ Cognito:
`https://example.com/#id_token=123&access_token=abc&expires_in=3600&token_type=Bearer`
❌ localstack:
`https://example.com/?id_token=123#id_token=123`

@leo Do you know anything about the above?

To test this, set the values in your `config/local` to the ones in the `config/staging`. Now that you're connected to the stanging env, go to:
```
http://localhost:9000/signin
```
Click `Sign up` and in the new page url replace `/signup?` with `/login?`.
