### PR TITLE
Error tracking

### DIFF
--- a/app/assets/scripts/components/common/toasts.js
+++ b/app/assets/scripts/components/common/toasts.js
@@ -59,7 +59,6 @@ export const createProcessToast = (msg) => {
         render: errorMsg,
         closeOnClick: true,
         closeButton: true,
-        autoClose: 5000,
         draggable: true
       })
   };

--- a/app/assets/scripts/components/dashboard/dash-contributor.js
+++ b/app/assets/scripts/components/dashboard/dash-contributor.js
@@ -183,7 +183,11 @@ const TabDocuments = (props) => {
   if (atbds.status === 'failed') {
     return (
       <EmptyTab>
-        <p>Something went wrong loading the documents. Please try again.</p>
+        <p>
+          Something went wrong loading the documents. Please try again.
+          <br />
+          Refresh the page if the error persists.
+        </p>
       </EmptyTab>
     );
   }

--- a/app/assets/scripts/components/dashboard/dash-curator.js
+++ b/app/assets/scripts/components/dashboard/dash-curator.js
@@ -74,7 +74,11 @@ function DashboardCurator() {
       )}
       {atbds.status === 'failed' && (
         <Empty>
-          <p>Something went wrong loading the documents. Please try again.</p>
+          <p>
+            Something went wrong loading the documents. Please try again.
+            <br />
+            Refresh the page if the error persists.
+          </p>
         </Empty>
       )}
 

--- a/app/assets/scripts/components/uhoh/fatal-error.js
+++ b/app/assets/scripts/components/uhoh/fatal-error.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import T from 'prop-types';
 import styled, { keyframes } from 'styled-components';
+import * as Sentry from "@sentry/react";
 import { antialiased, glsp } from '@devseed-ui/theme-provider';
 
 import { baseUrl } from '../../config';
@@ -149,6 +150,10 @@ export default class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = { error: null };
+  }
+
+  componentDidCatch(error, { componentStack }) {
+    Sentry.captureException(error, { contexts: { react: { componentStack } } });
   }
 
   render() {

--- a/app/assets/scripts/components/uhoh/fatal-error.js
+++ b/app/assets/scripts/components/uhoh/fatal-error.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import T from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { antialiased, glsp } from '@devseed-ui/theme-provider';
 
 import { baseUrl } from '../../config';
 import { starsImage, earthImage, satelliteImage } from './images';
+import Constrainer from '../../styles/constrainer';
 
 const rotateAnim = keyframes`
   from {
@@ -117,6 +119,28 @@ const EarthAnim = styled.div`
   }
 `;
 
+const ErrorDetails = styled.details`
+  text-align: left;
+
+  summary {
+    text-align: center;
+  }
+
+  > strong {
+    display: block;
+    font-size: 1.5rem;
+    margin-bottom: ${glsp()};
+  }
+`;
+
+const ErrorLine = styled.p`
+  margin-bottom: ${glsp()};
+
+  small {
+    display: block;
+  }
+`;
+
 export default class ErrorBoundary extends React.Component {
   static getDerivedStateFromError(error) {
     return { error: error };
@@ -157,6 +181,7 @@ export default class ErrorBoundary extends React.Component {
           <EarthAnim>
             <div />
           </EarthAnim>
+          <PrettyError error={this.state.error} />
         </PageBody>
       </Page>
     ) : (
@@ -165,3 +190,32 @@ export default class ErrorBoundary extends React.Component {
     );
   }
 }
+
+function PrettyError({ error }) {
+  const stack = error.stack.split('\n');
+
+  return (
+    <Constrainer>
+      <ErrorDetails>
+        <summary>Error details</summary>
+        <strong>
+          {error.name}: {error.message}
+        </strong>
+        {stack.map((l, i) => {
+          const [name, path] = l.split(/@(.*)/);
+          return (
+            /* eslint-disable-next-line react/no-array-index-key */
+            <ErrorLine key={i}>
+              {name}
+              <small>{path}</small>
+            </ErrorLine>
+          );
+        })}
+      </ErrorDetails>
+    </Constrainer>
+  );
+}
+
+PrettyError.propTypes = {
+  error: T.object
+};

--- a/app/assets/scripts/config/production.js
+++ b/app/assets/scripts/config/production.js
@@ -1,5 +1,7 @@
 // module exports is required to be able to load from gulpfile.
 module.exports = {
+  sentryDSN:
+    'https://ccb5ad14ce344c209ee7cd69a9dcda7c@o1180400.ingest.sentry.io/6293167',
   appTitle: 'Algorithm Publication Tool',
   appDescription: 'Algorithm Publication Tool - ATBD management.',
   apiUrl: 'https://xryfsg9blc.execute-api.us-west-2.amazonaws.com/v2',

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -1,6 +1,8 @@
 import '@babel/polyfill';
 import React, { useEffect } from 'react';
 import { render } from 'react-dom';
+import * as Sentry from '@sentry/react';
+import { BrowserTracing } from '@sentry/tracing';
 import T from 'prop-types';
 import { Router, Route, Switch, useLocation } from 'react-router-dom';
 import ReactGA from 'react-ga';
@@ -62,7 +64,19 @@ const composingComponents = [
   SearchProvider
 ];
 
-const { gaTrackingCode } = config;
+const { gaTrackingCode, sentryDSN } = config;
+
+Sentry.init({
+  dsn: sentryDSN,
+  integrations: [new BrowserTracing()],
+  release: `apt@v${process.env.APP_VERSION}`,
+  environment: process.env.NODE_ENV,
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for performance monitoring.
+  // We recommend adjusting this value in production
+  tracesSampleRate: 1.0
+});
 
 // Google analytics
 if (gaTrackingCode) {

--- a/package.json
+++ b/package.json
@@ -122,6 +122,8 @@
     "@devseed-ui/theme-provider": "^3.0.0",
     "@devseed-ui/toolbar": "2.1.2",
     "@devseed-ui/typography": "^1.0.0",
+    "@sentry/react": "^6.19.2",
+    "@sentry/tracing": "^6.19.2",
     "@udecode/slate-plugins": "0.75.2",
     "aws-amplify": "^4.1.1",
     "axios": "^0.21.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,81 @@
   resolved "https://registry.yarnpkg.com/@react-hook/merged-ref/-/merged-ref-1.3.0.tgz#0f482780e1eefc1abdc964dd3d04680186b07c8a"
   integrity sha512-9p7fbPZ37n1Cbw37f3EtrcR9TwVjMkoTKwYbG7URO2HDlnOzuNTjsd/VK0/4i52SwKmOa6lBwz6Pr9g0pIyaCg==
 
+"@sentry/browser@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2fbrowser/-/browser-6.19.2.tgz#c0f6df07584f3b36fa037067aea20b2c8c2095a3"
+  integrity sha512-5VC44p5Vu2eJhVT39nLAJFgha5MjHDYCyZRR1ieeZt3a++otojPGBBAKNAtrEMGV+A2Z9AoneD6ZnDVlyb3GKg==
+  dependencies:
+    "@sentry/core" "6.19.2"
+    "@sentry/types" "6.19.2"
+    "@sentry/utils" "6.19.2"
+    tslib "^1.9.3"
+
+"@sentry/core@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2fcore/-/core-6.19.2.tgz#dd35ba6ca41a2dd011c43f732bcdadbb52c06376"
+  integrity sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==
+  dependencies:
+    "@sentry/hub" "6.19.2"
+    "@sentry/minimal" "6.19.2"
+    "@sentry/types" "6.19.2"
+    "@sentry/utils" "6.19.2"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2fhub/-/hub-6.19.2.tgz#0e9f9c507e55d8396002f644b43ef27cc9ff1289"
+  integrity sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==
+  dependencies:
+    "@sentry/types" "6.19.2"
+    "@sentry/utils" "6.19.2"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2fminimal/-/minimal-6.19.2.tgz#e748541e4adbc7e80a3b6ccaf01b631c17fc44b4"
+  integrity sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==
+  dependencies:
+    "@sentry/hub" "6.19.2"
+    "@sentry/types" "6.19.2"
+    tslib "^1.9.3"
+
+"@sentry/react@^6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2freact/-/react-6.19.2.tgz#67760aed06d7e54a2e117cd9048ad19d573c78f1"
+  integrity sha512-6ffifcUWJegvC5iYJlXL3zBirR05F/i5nA7QaYSMERJqZpXuYhwNPySbuiNTajm64+HA1RbdQkiwrHE/Ur3f1w==
+  dependencies:
+    "@sentry/browser" "6.19.2"
+    "@sentry/minimal" "6.19.2"
+    "@sentry/types" "6.19.2"
+    "@sentry/utils" "6.19.2"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2ftracing/-/tracing-6.19.2.tgz#ed6ff1bc901c4d79ef97f77ed54ce58c650e4915"
+  integrity sha512-rGoPpP1JIAxdq5bzrww0XuNVr6yn7RN6/wUcaxf6CAvklKvDx+q28WTGlZLGTZ/3un8Rv6i1FZFZOXizgnVnrg==
+  dependencies:
+    "@sentry/hub" "6.19.2"
+    "@sentry/minimal" "6.19.2"
+    "@sentry/types" "6.19.2"
+    "@sentry/utils" "6.19.2"
+    tslib "^1.9.3"
+
+"@sentry/types@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2ftypes/-/types-6.19.2.tgz#0219c9da21ed975951108b8541913b1966464435"
+  integrity sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg==
+
+"@sentry/utils@6.19.2":
+  version "6.19.2"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sentry%2futils/-/utils-6.19.2.tgz#995efb896c5159369509f4896c27a2d2ea9191f2"
+  integrity sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==
+  dependencies:
+    "@sentry/types" "6.19.2"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
Branched from https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/352

I've been exploring error tracking and logging applications that remotely store errors details so we can more easily trace an error when it is reported.
I've looked at:
- [Sentry](https://sentry.io)
- [Data Dog](https://www.datadoghq.com/)
- [Log Rocket](https://logrocket.com/)

I didn't do an extensive analysis of all options, but I settled on Sentry since it is the one that seemed simpler to use and more dedicated to the error logging. The other options seemed more full service analytics.

This PR sets up Sentry logging, capturing uncaught errors and errors caught by React's error boundary (The screen with the satellite circling the planet.)  
Besides logging the stack trace it also logs some actions the user took like for example the items click (It does this referring to the DOM node path).

Because of the way the bundler builds the site it is not possible to use sourcemaps in the production environment, however I don't think that is critical for success. If this logging system ends up being useful we may consider a more detailed implementation with the inclusion of sourcemaps.

**Issues page:**
![Screen Shot 2022-03-28 at 18 27 23](https://user-images.githubusercontent.com/1090606/160454054-ecdfd724-a106-4b13-ac56-c5dc59e8702c.png)

**Single issue:**
![Screenshot 2022-03-28 at 18-28-07 Error fatal reviews! - developmentseed - apt](https://user-images.githubusercontent.com/1090606/160454038-24e7e2d0-8271-4e5f-ae25-dadd9cbde1b6.png)

---

I just realized that the free plan only offers 1 seat, so I can't give anyone access to this project. If we look at the paid alternative there are unlimited members.  
Is this a deal breaker? @leothomas @aboydnw @oliverroick 
