### PR TITLE
Save and load from local store

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/local-store.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store.js
@@ -1,7 +1,11 @@
-import { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import T from 'prop-types';
 import { useFormikContext } from 'formik';
+import styled from 'styled-components';
 import { useParams } from 'react-router';
 import defaultsDeep from 'lodash.defaultsdeep';
+import { toast } from 'react-toastify';
+import { Button as BaseButton } from '@devseed-ui/button';
 
 export class LocalAtbdStorage {
   constructor() {
@@ -45,12 +49,74 @@ export class LocalAtbdStorage {
   }
 }
 
+const Button = styled(BaseButton)`
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
+`;
+
+function RecoverToast({ recoverData, clearData, closeToast }) {
+  const handleRecover = () => {
+    recoverData();
+    closeToast();
+  };
+
+  const handleClear = () => {
+    clearData();
+    closeToast();
+  };
+
+  return (
+    <div>
+      <p>
+        We have recovered data that you had inserted. Do you want to restore the
+        data?
+      </p>
+      <Button
+        variation='primary-raised-light'
+        size='small'
+        type='button'
+        onClick={handleRecover}
+      >
+        Recover
+      </Button>
+      <Button
+        variation='primary-raised-light'
+        size='small'
+        type='button'
+        onClick={handleClear}
+      >
+        Discard
+      </Button>
+    </div>
+  );
+}
+
+RecoverToast.propTypes = {
+  recoverData: T.func.isRequired,
+  clearData: T.func.isRequired,
+  closeToast: T.func.isRequired
+};
+
 export function LocalStore({ atbd }) {
   const isInitialized = useRef();
   const { values, setValues, dirty } = useFormikContext();
   const { step } = useParams();
 
   const stepId = step || 'identifying_information';
+  const [displayRecoverToast, setDisplayRecoverToast] = useState(false);
+
+  const recoverData = useCallback(() => {
+    const localAtbdStorage = new LocalAtbdStorage();
+    const localValues = localAtbdStorage.getAtbd(atbd, stepId);
+    setValues(defaultsDeep(localValues, values));
+    setDisplayRecoverToast(false);
+  }, [atbd, values, setValues, stepId]);
+
+  const clearData = useCallback(() => {
+    const localAtbdStorage = new LocalAtbdStorage();
+    localAtbdStorage.removeAtbd(atbd, stepId);
+    setDisplayRecoverToast(false);
+  }, [atbd, stepId]);
 
   useEffect(() => {
     const localAtbdStorage = new LocalAtbdStorage();
@@ -64,12 +130,33 @@ export function LocalStore({ atbd }) {
       if (atbd) {
         const localValues = localAtbdStorage.getAtbd(atbd, stepId);
         if (localValues) {
-          setValues(defaultsDeep(localValues, values));
+          setDisplayRecoverToast(true);
         }
         isInitialized.current = true;
       }
     }
   }, [atbd, stepId, values, setValues, dirty]);
 
+  useEffect(() => {
+    if (displayRecoverToast) {
+      toast.info(
+        ({ closeToast }) => (
+          <RecoverToast
+            recoverData={recoverData}
+            clearData={clearData}
+            closeToast={closeToast}
+          />
+        ),
+        {
+          autoClose: false
+        }
+      );
+    }
+  }, [displayRecoverToast, clearData, recoverData]);
+
   return null;
 }
+
+LocalStore.propTypes = {
+  atbd: T.object.isRequired
+};

--- a/app/assets/scripts/components/documents/single-edit/local-store.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store.js
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { useFormikContext } from 'formik';
+import { useParams } from 'react-router';
+import defaultsDeep from 'lodash.defaultsdeep';
+
+export class LocalAtbdStorage {
+  constructor() {
+    this.expiry = 15 * 60000; // 15 minutes
+  }
+
+  getStorageKey(atbd) {
+    const { id, version } = atbd;
+    return `atbd/${id}/${version}`;
+  }
+
+  getAtbd(atbd) {
+    const key = this.getStorageKey(atbd);
+    const values = JSON.parse(localStorage.getItem(key));
+
+    if (values && values.created + this.expiry > Date.now()) {
+      // Return values if the store is not expired
+      return values;
+    }
+
+    // The store either doesn't exist or is expired,
+    // trying to remove the store
+    this.removeAtbd(atbd);
+    return undefined;
+  }
+
+  setAtbd(atbd, values) {
+    const key = this.getStorageKey(atbd);
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ...values,
+        created: Date.now()
+      })
+    );
+  }
+
+  removeAtbd(atbd) {
+    const key = this.getStorageKey(atbd);
+    localStorage.removeItem(key);
+  }
+}
+
+export function LocalStore({ atbd }) {
+  const isInitialized = useRef();
+  const { values, setValues, dirty } = useFormikContext();
+  const { step } = useParams();
+
+  useEffect(() => {
+    const localAtbdStorage = new LocalAtbdStorage();
+    if (isInitialized.current) {
+      if (dirty) {
+        const storeValue = { step, values };
+        localAtbdStorage.setAtbd(atbd, storeValue);
+      } else {
+        localAtbdStorage.removeAtbd(atbd);
+      }
+    } else {
+      if (atbd) {
+        const localValues = localAtbdStorage.getAtbd(atbd);
+        if (localValues && localValues.step === step) {
+          setValues(defaultsDeep(localValues.values, values));
+        } else {
+          localAtbdStorage.removeAtbd(atbd);
+        }
+        isInitialized.current = true;
+      }
+    }
+  }, [atbd, step, values, setValues, dirty]);
+
+  return null;
+}

--- a/app/assets/scripts/components/documents/single-edit/local-store/atbd-storage.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/atbd-storage.js
@@ -1,0 +1,41 @@
+export default class LocalAtbdStorage {
+  constructor() {
+    this.expiry = 15 * 60000; // 15 minutes
+  }
+
+  getStorageKey(atbd, step) {
+    const { id, version } = atbd;
+    return `atbd/${id}/${version}/${step}`;
+  }
+
+  getAtbd(atbd, step) {
+    const key = this.getStorageKey(atbd, step);
+    const values = JSON.parse(localStorage.getItem(key));
+
+    if (values && values.created + this.expiry > Date.now()) {
+      // Return values if the store is not expired
+      return values;
+    }
+
+    // The store either doesn't exist or is expired,
+    // trying to remove the store
+    this.removeAtbd(atbd, step);
+    return undefined;
+  }
+
+  setAtbd(atbd, step, values) {
+    const key = this.getStorageKey(atbd, step);
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ...values,
+        created: Date.now()
+      })
+    );
+  }
+
+  removeAtbd(atbd, step) {
+    const key = this.getStorageKey(atbd, step);
+    localStorage.removeItem(key);
+  }
+}

--- a/app/assets/scripts/components/documents/single-edit/local-store/index.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/index.js
@@ -16,6 +16,7 @@ export function LocalStore({ atbd }) {
 
   const stepId = step || 'identifying_information';
   const [displayRecoverToast, setDisplayRecoverToast] = useState(false);
+  const [isOutDated, setIsOutDated] = useState(false);
 
   const recoverData = useCallback(() => {
     const localAtbdStorage = new LocalAtbdStorage();
@@ -42,7 +43,9 @@ export function LocalStore({ atbd }) {
       if (atbd) {
         const localValues = localAtbdStorage.getAtbd(atbd, stepId);
         if (localValues) {
+          const atdbUpdated = new Date(atbd.last_updated_at).getTime();
           setDisplayRecoverToast(true);
+          setIsOutDated(localValues.created < atdbUpdated);
         }
         isInitialized.current = true;
       }
@@ -57,6 +60,7 @@ export function LocalStore({ atbd }) {
             recoverData={recoverData}
             clearData={clearData}
             closeToast={closeToast}
+            dataIsOutdated={isOutDated}
           />
         ),
         {
@@ -64,7 +68,7 @@ export function LocalStore({ atbd }) {
         }
       );
     }
-  }, [displayRecoverToast, clearData, recoverData]);
+  }, [displayRecoverToast, isOutDated, clearData, recoverData]);
 
   return null;
 }

--- a/app/assets/scripts/components/documents/single-edit/local-store/index.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/index.js
@@ -1,101 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import T from 'prop-types';
 import { useFormikContext } from 'formik';
-import styled from 'styled-components';
+
 import { useParams } from 'react-router';
 import defaultsDeep from 'lodash.defaultsdeep';
 import { toast } from 'react-toastify';
-import { Button as BaseButton } from '@devseed-ui/button';
 
-export class LocalAtbdStorage {
-  constructor() {
-    this.expiry = 15 * 60000; // 15 minutes
-  }
-
-  getStorageKey(atbd, step) {
-    const { id, version } = atbd;
-    return `atbd/${id}/${version}/${step}`;
-  }
-
-  getAtbd(atbd, step) {
-    const key = this.getStorageKey(atbd, step);
-    const values = JSON.parse(localStorage.getItem(key));
-
-    if (values && values.created + this.expiry > Date.now()) {
-      // Return values if the store is not expired
-      return values;
-    }
-
-    // The store either doesn't exist or is expired,
-    // trying to remove the store
-    this.removeAtbd(atbd, step);
-    return undefined;
-  }
-
-  setAtbd(atbd, step, values) {
-    const key = this.getStorageKey(atbd, step);
-    localStorage.setItem(
-      key,
-      JSON.stringify({
-        ...values,
-        created: Date.now()
-      })
-    );
-  }
-
-  removeAtbd(atbd, step) {
-    const key = this.getStorageKey(atbd, step);
-    localStorage.removeItem(key);
-  }
-}
-
-const Button = styled(BaseButton)`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
-`;
-
-function RecoverToast({ recoverData, clearData, closeToast }) {
-  const handleRecover = () => {
-    recoverData();
-    closeToast();
-  };
-
-  const handleClear = () => {
-    clearData();
-    closeToast();
-  };
-
-  return (
-    <div>
-      <p>
-        We have recovered data that you had inserted. Do you want to restore the
-        data?
-      </p>
-      <Button
-        variation='primary-raised-light'
-        size='small'
-        type='button'
-        onClick={handleRecover}
-      >
-        Recover
-      </Button>
-      <Button
-        variation='primary-raised-light'
-        size='small'
-        type='button'
-        onClick={handleClear}
-      >
-        Discard
-      </Button>
-    </div>
-  );
-}
-
-RecoverToast.propTypes = {
-  recoverData: T.func.isRequired,
-  clearData: T.func.isRequired,
-  closeToast: T.func.isRequired
-};
+import LocalAtbdStorage from './atbd-storage';
+import RecoverToast from './recover-toast';
 
 export function LocalStore({ atbd }) {
   const isInitialized = useRef();

--- a/app/assets/scripts/components/documents/single-edit/local-store/index.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/index.js
@@ -64,7 +64,8 @@ export function LocalStore({ atbd }) {
           />
         ),
         {
-          autoClose: false
+          autoClose: false,
+          closeButton: false
         }
       );
     }

--- a/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import T from 'prop-types';
+import styled from 'styled-components';
+
+import { Button as BaseButton } from '@devseed-ui/button';
+
+const Button = styled(BaseButton)`
+  margin-top: 0.5rem;
+  margin-right: 0.5rem;
+`;
+
+export default function RecoverToast({ recoverData, clearData, closeToast }) {
+  const handleRecover = () => {
+    recoverData();
+    closeToast();
+  };
+
+  const handleClear = () => {
+    clearData();
+    closeToast();
+  };
+
+  return (
+    <div>
+      <p>
+        We have recovered data that you had inserted. Do you want to restore the
+        data?
+      </p>
+      <Button
+        variation='primary-raised-light'
+        size='small'
+        type='button'
+        onClick={handleRecover}
+      >
+        Recover
+      </Button>
+      <Button
+        variation='primary-raised-light'
+        size='small'
+        type='button'
+        onClick={handleClear}
+      >
+        Discard
+      </Button>
+    </div>
+  );
+}
+
+RecoverToast.propTypes = {
+  recoverData: T.func.isRequired,
+  clearData: T.func.isRequired,
+  closeToast: T.func.isRequired
+};

--- a/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
@@ -2,11 +2,18 @@ import React from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 
-import { Button as BaseButton } from '@devseed-ui/button';
+import { glsp } from '@devseed-ui/theme-provider';
+import { Button } from '@devseed-ui/button';
 
-const Button = styled(BaseButton)`
-  margin-top: 0.5rem;
-  margin-right: 0.5rem;
+const ToastWrapper = styled.div`
+  display: flex;
+  flex-flow: column;
+  gap: ${glsp()};
+`;
+const ToastControls = styled.div`
+  display: flex;
+  flex-flow: row;
+  gap: ${glsp()};
 `;
 
 export default function RecoverToast(props) {
@@ -22,33 +29,35 @@ export default function RecoverToast(props) {
   };
 
   return (
-    <>
+    <ToastWrapper>
       <p>
         We have recovered data that you had inserted. Do you want to restore the
         data?
       </p>
       {dataIsOutdated && (
-        <p>
+        <strong>
           Restoring the data will overwrite a more recent update to the ATBD.
-        </p>
+        </strong>
       )}
-      <Button
-        variation='primary-raised-light'
-        size='small'
-        type='button'
-        onClick={handleRecover}
-      >
-        Recover
-      </Button>
-      <Button
-        variation='primary-raised-light'
-        size='small'
-        type='button'
-        onClick={handleClear}
-      >
-        Discard
-      </Button>
-    </>
+      <ToastControls>
+        <Button
+          variation='primary-raised-light'
+          useIcon='tick--small'
+          type='button'
+          onClick={handleRecover}
+        >
+          Recover
+        </Button>
+        <Button
+          variation='achromic-glass'
+          useIcon='trash-bin'
+          type='button'
+          onClick={handleClear}
+        >
+          Discard
+        </Button>
+      </ToastControls>
+    </ToastWrapper>
   );
 }
 

--- a/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/recover-toast.js
@@ -9,7 +9,8 @@ const Button = styled(BaseButton)`
   margin-right: 0.5rem;
 `;
 
-export default function RecoverToast({ recoverData, clearData, closeToast }) {
+export default function RecoverToast(props) {
+  const { recoverData, clearData, closeToast, dataIsOutdated } = props;
   const handleRecover = () => {
     recoverData();
     closeToast();
@@ -21,11 +22,16 @@ export default function RecoverToast({ recoverData, clearData, closeToast }) {
   };
 
   return (
-    <div>
+    <>
       <p>
         We have recovered data that you had inserted. Do you want to restore the
         data?
       </p>
+      {dataIsOutdated && (
+        <p>
+          Restoring the data will overwrite a more recent update to the ATBD.
+        </p>
+      )}
       <Button
         variation='primary-raised-light'
         size='small'
@@ -42,12 +48,13 @@ export default function RecoverToast({ recoverData, clearData, closeToast }) {
       >
         Discard
       </Button>
-    </div>
+    </>
   );
 }
 
 RecoverToast.propTypes = {
   recoverData: T.func.isRequired,
   clearData: T.func.isRequired,
-  closeToast: T.func.isRequired
+  closeToast: T.func.isRequired,
+  dataIsOutdated: T.bool
 };

--- a/app/assets/scripts/components/documents/single-edit/step-algo-description.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-description.js
@@ -22,6 +22,7 @@ import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { editorEmptyValue } from '../../slate';
 import { getDocumentSectionLabel } from './sections';
+import { LocalStore } from './local-store';
 
 const DeletableFieldsetTriptych = styled(DeletableFieldset)`
   ${FormFieldsetBody} {
@@ -54,6 +55,7 @@ export default function StepAlgoDescription(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
@@ -17,6 +17,7 @@ import { useSingleAtbd } from '../../../context/atbds-list';
 import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
+import { LocalStore } from './local-store';
 
 // The initial value is the same for
 // Algorithm Implementations
@@ -45,6 +46,7 @@ export default function StepAlgoImplementation(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
@@ -13,6 +13,7 @@ import { useSingleAtbd } from '../../../context/atbds-list';
 import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
+import { LocalStore } from './local-store';
 
 export default function StepAlgoUsage(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -31,6 +32,7 @@ export default function StepAlgoUsage(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -15,6 +15,7 @@ import { useSingleAtbd } from '../../../../context/atbds-list';
 import { useSubmitForVersionData } from '../use-submit';
 import { formString } from '../../../../utils/strings';
 import { getDocumentSectionLabel } from '../sections';
+import { LocalStore } from '../local-store';
 
 export default function StepCloseout(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -39,6 +40,7 @@ export default function StepCloseout(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
@@ -21,6 +21,7 @@ import { useContacts } from '../../../../context/contacts-list';
 import { validateContact } from '../../../contacts/contact-utils';
 import { getDocumentSectionLabel } from '../sections';
 import { documentEdit } from '../../../../utils/url-creator';
+import { LocalStore } from '../local-store';
 
 export default function StepContacts(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -93,6 +94,7 @@ export default function StepContacts(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         {contacts.status === 'loading' && <GlobalLoading />}
         {contacts.status === 'succeeded' && (

--- a/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
+++ b/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
@@ -20,6 +20,7 @@ import { formStringSymbol, citationFields } from '../citation';
 import { useSubmitForMetaAndVersionData } from './use-submit';
 import { getDocumentSectionLabel } from './sections';
 import { isPublished } from '../status';
+import { LocalStore } from './local-store';
 
 export default function StepIdentifyingInformation(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -58,6 +59,7 @@ export default function StepIdentifyingInformation(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-introduction.js
+++ b/app/assets/scripts/components/documents/single-edit/step-introduction.js
@@ -13,6 +13,7 @@ import { useSingleAtbd } from '../../../context/atbds-list';
 import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
+import { LocalStore } from './local-store';
 
 export default function StepIntroduction(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -31,6 +32,7 @@ export default function StepIntroduction(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-references/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-references/index.js
@@ -11,6 +11,7 @@ import ReferencesManager from './references-manager';
 import { useSingleAtbd } from '../../../../context/atbds-list';
 import { useSubmitForVersionData } from '../use-submit';
 import { createDocumentReferenceIndex } from '../../../../utils/references';
+import { LocalStore } from '../local-store';
 
 export default function StepReferences(props) {
   const { renderInpageHeader, atbd, id, version, step } = props;
@@ -48,6 +49,7 @@ export default function StepReferences(props) {
       onSubmit={onSubmit}
     >
       <Inpage>
+        <LocalStore atbd={atbd} />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>


### PR DESCRIPTION
Resolves https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/340

- I implemented the functionality into a React component `LocalStore`, which is added to each of the Formik instances of the editor. Placing the component inside Formik allows us to listen to value changes in any of the form's fields and act accordingly. 
- When a form is initialised, we look for a value in local storage and merge with the values taken from the form state, with values from local storage taking precedence. 
	- If the values from local storage are for a different step, we take the original form values without merging and we clear the local storage. This is in line with the current behaviour where you lose changes when moving to another step without saving. 
- If the current form is `dirty`, ie. values have changed, then we save the form values to local storage. 
- If the current form is not `dirty`, ie. no values have changed or the form has been saved, then we clear any values from local storage. 
- Each stored value expires after 15 minutes. This should be enough time to recover from an error or accidental reload. Whenever the page is reloaded, the expiry is extended by another 15 minutes, which is expected since we want to give editors time to continue editing and to save their changes. 
- I encapsulated any interaction with local storage into it's own class `LocalAtbdStorage` so the React component does need to deal with constructing the right keys, unpacking values and timing out stored values.  
