### PR TITLE
Add save-and-continue button to document form

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -274,16 +274,15 @@ const SaveAndContinueButton = ({ nextStep }) => {
   const history = useHistory();
   const { dirty, isSubmitting, submitForm, status } = useFormikContext();
   const submitAndContinue = useCallback(
-    (e) => {
-      submitForm(e).then(({ error, data }) => {
-        if (!error) {
-          if (nextStep) {
-            history.replace(documentEdit(data.alias, data.version, nextStep));
-          } else {
-            history.replace(documentView(data.alias, data.version));
-          }
+    async (e) => {
+      const { error, data } = await submitForm(e);
+      if (!error) {
+        if (nextStep) {
+          history.replace(documentEdit(data.alias, data.version, nextStep));
+        } else {
+          history.replace(documentView(data.alias, data.version));
         }
-      });
+      }
     },
     [submitForm, history, nextStep]
   );

--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -295,7 +295,7 @@ const SaveAndContinueButton = ({ nextStep }) => {
       onClick={submitAndContinue}
       useIcon='tick--small'
     >
-      Save and {nextStep ? 'continue' : 'view'}
+      Save &amp; {nextStep ? 'continue' : 'view'}
     </Button>
   );
 };

--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -5,6 +5,7 @@ import { useHistory, useParams } from 'react-router';
 import { useFormikContext } from 'formik';
 import { GlobalLoading } from '@devseed-ui/global-loading';
 import { VerticalDivider } from '@devseed-ui/toolbar';
+import { Button } from '@devseed-ui/button';
 
 import App from '../../common/app';
 import { InpageHeaderSticky, InpageActions } from '../../../styles/inpage';
@@ -284,14 +285,15 @@ const SaveAndContinueButton = ({ nextStep }) => {
   );
 
   return (
-    <ButtonSecondary
+    <Button
+      variation='primary-raised-dark'
       title='Save current changes and continue to next step'
       disabled={isSubmitting || !dirty || status?.working}
       onClick={submitAndContinue}
       useIcon='tick--small'
     >
       Save {nextStep && ' and continue'}
-    </ButtonSecondary>
+    </Button>
   );
 };
 

--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
+import T from 'prop-types';
+import styled from 'styled-components';
 import { useHistory, useParams } from 'react-router';
 import { useFormikContext } from 'formik';
 import { GlobalLoading } from '@devseed-ui/global-loading';
@@ -16,7 +18,7 @@ import { DocumentModals, useDocumentModals } from '../use-document-modals';
 import ClosedReviewForbidden from './closed-review-forbidden';
 import Forbidden from '../../../a11n/forbidden';
 
-import { getDocumentEditStep } from './steps';
+import { getDocumentEditStep, getNextDocumentEditStep } from './steps';
 import {
   useSingleAtbd,
   useSingleAtbdEvents
@@ -31,6 +33,13 @@ import {
 import { useThreadStats } from '../../../context/threads-list';
 import { useEffectPrevious } from '../../../utils/use-effect-previous';
 import { useSaveTooltipPlacement } from '../../../utils/use-save-tooltip-placement';
+import { documentEdit } from '../../../utils/url-creator';
+
+const FormFooter = styled.div`
+  display: flex;
+  align-items: right;
+  justify-content: right;
+`;
 
 function DocumentEdit() {
   const { id, version, step } = useParams();
@@ -133,6 +142,7 @@ function DocumentEdit() {
   }
 
   const stepDefinition = getDocumentEditStep(step);
+  const nextStepDefinition = getNextDocumentEditStep(step);
 
   // During the closed review process the document can't be edited.
   // Show a message instead of a step.
@@ -202,6 +212,15 @@ function DocumentEdit() {
               </InpageActions>
             </InpageHeaderSticky>
           )}
+          renderFormFooter={() => {
+            return (
+              !isClosedReview(atbd.data) && (
+                <FormFooter>
+                  <SaveAndContinueButton nextStep={nextStepDefinition.id} />
+                </FormFooter>
+              )
+            );
+          }}
         />
       )}
     </App>
@@ -248,4 +267,34 @@ const SaveButton = () => {
       </ButtonSecondary>
     </Tip>
   );
+};
+
+const SaveAndContinueButton = ({ nextStep }) => {
+  const history = useHistory();
+  const { dirty, isSubmitting, submitForm, status } = useFormikContext();
+  const submitAndContinue = useCallback(
+    (e) => {
+      submitForm(e).then(({ error, data }) => {
+        if (!error && nextStep) {
+          history.replace(documentEdit(data.alias, data.version, nextStep));
+        }
+      });
+    },
+    [submitForm, history, nextStep]
+  );
+
+  return (
+    <ButtonSecondary
+      title='Save current changes and continue to next step'
+      disabled={isSubmitting || !dirty || status?.working}
+      onClick={submitAndContinue}
+      useIcon='tick--small'
+    >
+      Save {nextStep && ' and continue'}
+    </ButtonSecondary>
+  );
+};
+
+SaveAndContinueButton.propTypes = {
+  nextStep: T.string
 };

--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -34,7 +34,7 @@ import {
 import { useThreadStats } from '../../../context/threads-list';
 import { useEffectPrevious } from '../../../utils/use-effect-previous';
 import { useSaveTooltipPlacement } from '../../../utils/use-save-tooltip-placement';
-import { documentEdit } from '../../../utils/url-creator';
+import { documentEdit, documentView } from '../../../utils/url-creator';
 
 const FormFooter = styled.div`
   display: flex;
@@ -276,8 +276,12 @@ const SaveAndContinueButton = ({ nextStep }) => {
   const submitAndContinue = useCallback(
     (e) => {
       submitForm(e).then(({ error, data }) => {
-        if (!error && nextStep) {
-          history.replace(documentEdit(data.alias, data.version, nextStep));
+        if (!error) {
+          if (nextStep) {
+            history.replace(documentEdit(data.alias, data.version, nextStep));
+          } else {
+            history.replace(documentView(data.alias, data.version));
+          }
         }
       });
     },
@@ -292,7 +296,7 @@ const SaveAndContinueButton = ({ nextStep }) => {
       onClick={submitAndContinue}
       useIcon='tick--small'
     >
-      Save {nextStep && ' and continue'}
+      Save and {nextStep ? 'continue' : 'view'}
     </Button>
   );
 };

--- a/app/assets/scripts/components/documents/single-edit/step-algo-description.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-description.js
@@ -38,7 +38,14 @@ const variableFieldsEmptyValue = {
 };
 
 export default function StepAlgoDescription(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const initialValues = step.getInitialValues(atbd);
@@ -130,6 +137,7 @@ export default function StepAlgoDescription(props) {
                   fieldEmptyMessage='There are no Output Variables. You can start by adding one.'
                 />
               </RichTextContex2Formik>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -140,6 +148,7 @@ export default function StepAlgoDescription(props) {
 
 StepAlgoDescription.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
@@ -29,7 +29,14 @@ const emptyFieldValue = {
 };
 
 export default function StepAlgoImplementation(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const initialValues = step.getInitialValues(atbd);
@@ -95,6 +102,7 @@ export default function StepAlgoImplementation(props) {
                   fieldEmptyMessage='There are no Important Related Urls. You can start by adding one.'
                 />
               </RichTextContex2Formik>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -105,6 +113,7 @@ export default function StepAlgoImplementation(props) {
 
 StepAlgoImplementation.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
@@ -15,7 +15,14 @@ import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
 
 export default function StepAlgoUsage(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const initialValues = step.getInitialValues(atbd);
@@ -85,6 +92,7 @@ export default function StepAlgoUsage(props) {
                   />
                 </FormikSectionFieldset>
               </RichTextContex2Formik>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -95,6 +103,7 @@ export default function StepAlgoUsage(props) {
 
 StepAlgoUsage.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -17,7 +17,14 @@ import { formString } from '../../../../utils/strings';
 import { getDocumentSectionLabel } from '../sections';
 
 export default function StepCloseout(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
 
@@ -65,6 +72,7 @@ export default function StepCloseout(props) {
 
                 <JournalDetailsSection atbd={atbd} />
               </RichTextContex2Formik>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -75,6 +83,7 @@ export default function StepCloseout(props) {
 
 StepCloseout.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
@@ -23,7 +23,14 @@ import { getDocumentSectionLabel } from '../sections';
 import { documentEdit } from '../../../../utils/url-creator';
 
 export default function StepContacts(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const {
@@ -125,6 +132,7 @@ export default function StepContacts(props) {
                   </FormSectionNotes>
                   <ContactsList contactsList={contacts.data} />
                 </FormikSectionFieldset>
+                {renderFormFooter()}
               </Form>
             </FormBlock>
           </InpageBody>
@@ -136,6 +144,7 @@ export default function StepContacts(props) {
 
 StepContacts.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
+++ b/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
@@ -22,7 +22,14 @@ import { getDocumentSectionLabel } from './sections';
 import { isPublished } from '../status';
 
 export default function StepIdentifyingInformation(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
 
@@ -143,6 +150,7 @@ export default function StepIdentifyingInformation(props) {
                   />
                 ))}
               </FormikSectionFieldset>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -153,6 +161,7 @@ export default function StepIdentifyingInformation(props) {
 
 StepIdentifyingInformation.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-introduction.js
+++ b/app/assets/scripts/components/documents/single-edit/step-introduction.js
@@ -15,7 +15,14 @@ import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
 
 export default function StepIntroduction(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const initialValues = step.getInitialValues(atbd);
@@ -73,6 +80,7 @@ export default function StepIntroduction(props) {
                   />
                 </FormikSectionFieldset>
               </RichTextContex2Formik>
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -83,6 +91,7 @@ export default function StepIntroduction(props) {
 
 StepIntroduction.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/step-references/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-references/index.js
@@ -13,7 +13,14 @@ import { useSubmitForVersionData } from '../use-submit';
 import { createDocumentReferenceIndex } from '../../../../utils/references';
 
 export default function StepReferences(props) {
-  const { renderInpageHeader, atbd, id, version, step } = props;
+  const {
+    renderInpageHeader,
+    renderFormFooter,
+    atbd,
+    id,
+    version,
+    step
+  } = props;
 
   const { updateAtbd } = useSingleAtbd({ id, version });
   const initialValues = step.getInitialValues(atbd);
@@ -54,6 +61,7 @@ export default function StepReferences(props) {
             <FormBlockHeading>{step.label}</FormBlockHeading>
             <Form as={FormikForm}>
               <ReferencesManager referenceIndex={referenceIndex} />
+              {renderFormFooter()}
             </Form>
           </FormBlock>
         </InpageBody>
@@ -64,6 +72,7 @@ export default function StepReferences(props) {
 
 StepReferences.propTypes = {
   renderInpageHeader: T.func,
+  renderFormFooter: T.func,
   step: T.object,
   id: T.oneOfType([T.string, T.number]),
   version: T.string,

--- a/app/assets/scripts/components/documents/single-edit/steps.js
+++ b/app/assets/scripts/components/documents/single-edit/steps.js
@@ -305,3 +305,11 @@ export const getDocumentEditStep = (id) => {
     ...STEPS[idx]
   };
 };
+
+export const getNextDocumentEditStep = (id) => {
+  const currentStep = getDocumentEditStep(id);
+  return {
+    stepNum: currentStep.stepNum + 1,
+    ...STEPS[currentStep.stepNum]
+  };
+};

--- a/app/assets/scripts/components/documents/single-edit/use-submit.js
+++ b/app/assets/scripts/components/documents/single-edit/use-submit.js
@@ -42,6 +42,8 @@ export function useSubmitForMetaAndVersionData(updateAtbd, atbd, step) {
           }
         }
       }
+
+      return result;
     },
     [updateAtbd, history, atbd.status, atbd.version, step.id]
   );
@@ -89,6 +91,8 @@ export function useSubmitForVersionData(updateAtbd, atbd, hook) {
           }
         }
       }
+
+      return result;
     },
     [updateAtbd, history, atbd.version, atbd.status, hook]
   );
@@ -269,10 +273,14 @@ export function useSubmitForAtbdContacts({
         contacts_link: newContactsLink
       });
 
+      let result = {
+        error: erroredTask
+      };
+
       if (!erroredTask) {
         /* eslint-disable-next-line no-unused-vars */
         const { contacts_link: _, ...otherValues } = values;
-        const result = await updateAtbd({
+        result = await updateAtbd({
           ...otherValues,
           // When posting the atbd data the contacts_link has a different
           // structure.
@@ -299,6 +307,7 @@ export function useSubmitForAtbdContacts({
       }
 
       setSubmitting(false);
+      return result;
     },
     [contactsList, updateAtbd, createContact, updateContactUnbound]
   );


### PR DESCRIPTION
This PR adds introduces wizard-like functionality to the ATDB form, allowing users to save the form and redirect to the next step in the form. Contributes to #476

- Adds function `getNextDocumentEditStep`, which returns the following step ID from the current one. 
- Adds `SaveAndContinueButton`, which submits the form and redirects to the next step if the form has been submitted successfully. 
- Adds new prop `renderFormFooter` to form components, which we use to render the `SaveAndContinueButton` into each form.
- Returns results from the following submit handlers, so we know when `SaveAndContinueButton` needs to redirect to the next step:
  - `useSubmitForMetaAndVersionData`
  - `useSubmitForVersionData`
  - `useSubmitForAtbdContacts`