### PR TITLE
Change plain_summary and abstract to rich text fields

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -6,7 +6,6 @@ import { Form, FormHelperCounter } from '@devseed-ui/form';
 import { Inpage, InpageBody } from '../../../../styles/inpage';
 import { FormBlock, FormBlockHeading } from '../../../../styles/form-block';
 import RichTextContex2Formik from '../rich-text-ctx-formik';
-import { FormikInputTextarea } from '../../../common/forms/input-textarea';
 import { FormikSectionFieldset } from '../../../common/forms/section-fieldset';
 import { FormikInputEditor } from '../../../common/forms/input-editor';
 import KeywordsField, { updateKeywordValues } from './field-keywords';
@@ -98,13 +97,27 @@ StepCloseout.propTypes = {
 
 const MAX_ABSTRACT_WORDS = 250;
 
+function wordCount(value) {
+  const keys = Object.keys(value);
+
+  if (keys.includes('children')) {
+    return value.children.reduce((sum, child) => sum + wordCount(child), 0);
+  }
+
+  if (keys.includes('text')) {
+    const trimmed = value.text.trim();
+    return trimmed ? trimmed.split(/\s+/).length : 0;
+  }
+
+  return 0;
+}
+
 function FieldAbstract() {
   const [{ value }] = useField('document.abstract');
-  const trimmed = value.trim();
-  const words = trimmed ? trimmed.split(/\s+/).length : 0;
+  const words = wordCount(value);
 
   return (
-    <FormikInputTextarea
+    <FormikInputEditor
       id='abstract'
       name='document.abstract'
       label='Short ATBD summary'

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -8,6 +8,7 @@ import { FormBlock, FormBlockHeading } from '../../../../styles/form-block';
 import RichTextContex2Formik from '../rich-text-ctx-formik';
 import { FormikInputTextarea } from '../../../common/forms/input-textarea';
 import { FormikSectionFieldset } from '../../../common/forms/section-fieldset';
+import { FormikInputEditor } from '../../../common/forms/input-editor';
 import KeywordsField, { updateKeywordValues } from './field-keywords';
 import JournalDetailsSection from './journal-details';
 
@@ -61,7 +62,7 @@ export default function StepCloseout(props) {
                 >
                   <FieldAbstract />
 
-                  <FormikInputTextarea
+                  <FormikInputEditor
                     id='plain_summary'
                     name='document.plain_summary'
                     label='Plain Language Summary'

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -97,11 +97,14 @@ StepCloseout.propTypes = {
 
 const MAX_ABSTRACT_WORDS = 250;
 
-function wordCount(value) {
+function wordCountFromSlateValue(value) {
   const keys = Object.keys(value);
 
   if (keys.includes('children')) {
-    return value.children.reduce((sum, child) => sum + wordCount(child), 0);
+    return value.children.reduce(
+      (sum, child) => sum + wordCountFromSlateValue(child),
+      0
+    );
   }
 
   if (keys.includes('text')) {
@@ -114,7 +117,7 @@ function wordCount(value) {
 
 function FieldAbstract() {
   const [{ value }] = useField('document.abstract');
-  const words = wordCount(value);
+  const words = wordCountFromSlateValue(value);
 
   return (
     <FormikInputEditor

--- a/app/assets/scripts/components/documents/single-edit/steps.js
+++ b/app/assets/scripts/components/documents/single-edit/steps.js
@@ -250,7 +250,7 @@ export const STEPS = [
       return getValuesFromObj(atbd, {
         journal_status: JOURNAL_NO_PUBLICATION,
         document: {
-          abstract: '',
+          abstract: EDITOR_SYM,
           plain_summary: EDITOR_SYM,
           key_points: '',
           journal_discussion: EDITOR_SYM,

--- a/app/assets/scripts/components/documents/single-edit/steps.js
+++ b/app/assets/scripts/components/documents/single-edit/steps.js
@@ -251,7 +251,7 @@ export const STEPS = [
         journal_status: JOURNAL_NO_PUBLICATION,
         document: {
           abstract: '',
-          plain_summary: '',
+          plain_summary: EDITOR_SYM,
           key_points: '',
           journal_discussion: EDITOR_SYM,
           journal_acknowledgements: EDITOR_SYM,

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -306,6 +306,8 @@ export const atbdContentSections = [
   {
     label: 'Abstract',
     id: 'abstract',
+    editorSubsections: (document, { id }) =>
+      subsectionsFromSlateDocument(document.abstract, id),
     render: ({ element, document, referencesUseIndex, atbd }) => (
       <AtbdSection key={element.id} id={element.id} title={element.label}>
         <SafeReadEditor
@@ -325,6 +327,8 @@ export const atbdContentSections = [
   {
     label: 'Plain Language Summary',
     id: 'plain_summary',
+    editorSubsections: (document, { id }) =>
+      subsectionsFromSlateDocument(document.plain_summary, id),
     render: ({ element, document, referencesUseIndex, atbd }) => (
       <AtbdSection key={element.id} id={element.id} title={element.label}>
         <SafeReadEditor

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -318,9 +318,16 @@ export const atbdContentSections = [
   {
     label: 'Plain Language Summary',
     id: 'plain_summary',
-    render: ({ element, document }) => (
+    render: ({ element, document, referencesUseIndex, atbd }) => (
       <AtbdSection key={element.id} id={element.id} title={element.label}>
-        <MultilineString
+        <SafeReadEditor
+          context={{
+            subsectionLevel: 'h3',
+            sectionId: element.id,
+            references: document.publication_references,
+            referencesUseIndex,
+            atbd
+          }}
           value={document.plain_summary}
           whenEmpty={<EmptySection />}
         />

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -306,9 +306,16 @@ export const atbdContentSections = [
   {
     label: 'Abstract',
     id: 'abstract',
-    render: ({ element, document }) => (
+    render: ({ element, document, referencesUseIndex, atbd }) => (
       <AtbdSection key={element.id} id={element.id} title={element.label}>
-        <MultilineString
+        <SafeReadEditor
+          context={{
+            subsectionLevel: 'h3',
+            sectionId: element.id,
+            references: document.publication_references,
+            referencesUseIndex,
+            atbd
+          }}
           value={document.abstract}
           whenEmpty={<EmptySection />}
         />


### PR DESCRIPTION
Implements https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/331

- Changes `abstract` and `plain_summary` to `FormikInputEditor` fields.
- Adds a new function to count words for rich-text fields.
- Changes how `abstract` and `plain_summary` are rendered in the document view mode

How to test:

- Run these changes against the [corresponding backend changes](https://github.com/NASA-IMPACT/nasa-apt/pull/496)
