### PR TITLE
Equation popup

### DIFF
--- a/app/assets/scripts/components/slate/editor.js
+++ b/app/assets/scripts/components/slate/editor.js
@@ -27,7 +27,11 @@ import { withEmptyEditor } from './plugins/common/with-empty-editor';
 import { ExitBreakPlugin, SoftBreakPlugin } from './plugins/block-breaks';
 import { ParagraphPlugin } from './plugins/paragraph';
 import { ListPlugin, withList } from './plugins/list';
-import { EquationPlugin } from './plugins/equation';
+import {
+  EquationPlugin,
+  EquationModal,
+  withEquationModal
+} from './plugins/equation';
 import { SubSectionPlugin, withSubsectionId } from './plugins/subsection';
 import {
   LinkPlugin,
@@ -101,6 +105,7 @@ const withPlugins = [
   withLink,
   withLinkEditor,
   withReferenceModal,
+  withEquationModal,
   withSubsectionId,
   withCaption,
   withCaptionLayout([
@@ -145,6 +150,7 @@ export function RichTextEditor(props) {
         <EditorFloatingToolbar plugins={plugins} />
         <EditorLinkToolbar />
         <ReferencesModal />
+        <EquationModal />
         <ShortcutsModal plugins={plugins} />
         <LatexModal />
 

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -8,7 +8,7 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { visuallyHidden } from '@devseed-ui/theme-provider';
 import { headingAlt } from '@devseed-ui/typography';
 import collecticon from '@devseed-ui/collecticons';
-import { FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
+import { FormLabel, FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
 import { Button } from '@devseed-ui/button';
 import { upsertEquation } from '.';
 
@@ -122,8 +122,23 @@ export default function EquationEditor(props) {
     editor.equationModal.reset();
   };
 
+  const showInfo = () => {
+    editor.simpleModal.show({ id: 'latex-modal' });
+  };
+
   return (
     <>
+      <FormLabel id='equation'>
+        Enter Latex code
+        <Button
+          type='button'
+          useIcon='circle-information'
+          hideText
+          onClick={showInfo}
+        >
+          Latex cheatsheet
+        </Button>
+      </FormLabel>
       <FormTextarea
         ref={textareaRef}
         id='equation'

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -18,9 +18,9 @@ const EQUATION_PDF_THRESHOLD = 600;
 const FormTextarea = styled(BaseFormTextarea)`
   font-family: monospace;
   width: 100%;
-  height: 33px;
-  min-height: 33px;
-  transition: none;
+  height: 34px;
+  min-height: 34px;
+  transition: border 0.24s ease 0s;
 `;
 
 const EquationPreview = styled.aside`

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -119,6 +119,7 @@ export default function EquationEditor(props) {
   const handleSave = () => {
     const path = element && ReactEditor.findPath(editor, element);
     upsertEquation(editor, latexEquation, path);
+    editor.equationModal.reset();
   };
 
   return (

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -2,14 +2,13 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { Editor, Node, Transforms } from 'slate';
-import { ReactEditor, useEditor, useReadOnly } from 'slate-react';
+import { ReactEditor, useEditor } from 'slate-react';
 import { BlockMath } from 'react-katex';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { visuallyHidden } from '@devseed-ui/theme-provider';
 import { headingAlt } from '@devseed-ui/typography';
 import collecticon from '@devseed-ui/collecticons';
-
-import DeletableBlock from '../common/deletable-block';
+import { FormInput } from '@devseed-ui/form';
 
 const EQUATION_PDF_THRESHOLD = 600;
 
@@ -86,14 +85,12 @@ const EquationPreviewBody = styled.div`
 `;
 
 export default function EquationEditor(props) {
-  const { attributes, children, element } = props;
-  const readOnly = useReadOnly();
+  const { attributes, element, equation } = props;
   const editor = useEditor();
   const equationBlockRef = useRef();
   const [isTooLong, setTooLong] = useState(false);
-
-  const latexEquation = Node.string(element);
-  const equation = <BlockMath math={latexEquation || 'latex~empty~equation'} />;
+  const [latexEquation, setLatexEquation] = useState(equation);
+  console.log(equation);
 
   useEffect(() => {
     const node = equationBlockRef.current;
@@ -127,12 +124,17 @@ export default function EquationEditor(props) {
     [editor, element]
   );
 
-  return readOnly ? (
-    <EquationPreviewBody {...attributes}>{equation}</EquationPreviewBody>
-  ) : (
-    <DeletableBlock deleteAction='delete-equation' {...attributes}>
+  const handleInputChange = (e) => setLatexEquation(e.target.value);
+
+  return (
+    <>
       <EquationInput spellCheck={false}>
-        <code>{children}</code>
+        <FormInput
+          id='equation'
+          name='equation'
+          value={latexEquation}
+          onChange={handleInputChange}
+        />
       </EquationInput>
       <EquationPreview
         // Both contentEditable style and are needed for the click to work. See
@@ -153,15 +155,16 @@ export default function EquationEditor(props) {
           )}
         </EquationPreviewHeader>
         <EquationPreviewBody ref={equationBlockRef}>
-          {equation}
+          <BlockMath math={latexEquation} />;
         </EquationPreviewBody>
       </EquationPreview>
-    </DeletableBlock>
+    </>
   );
 }
 
 EquationEditor.propTypes = {
   attributes: T.object,
   children: T.node,
-  element: T.object
+  element: T.object,
+  equation: T.string
 };

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { Node } from 'slate';
@@ -8,13 +8,18 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { visuallyHidden } from '@devseed-ui/theme-provider';
 import { headingAlt } from '@devseed-ui/typography';
 import collecticon from '@devseed-ui/collecticons';
-import { FormInput } from '@devseed-ui/form';
+import { FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
+import { Button } from '@devseed-ui/button';
 import { upsertEquation } from '.';
 
 const EQUATION_PDF_THRESHOLD = 600;
 
-const EquationInput = styled.p`
+const FormTextarea = styled(BaseFormTextarea)`
   font-family: monospace;
+  width: 100%;
+  height: 33px;
+  min-height: 33px;
+  transition: none;
 `;
 
 const EquationPreview = styled.aside`
@@ -24,6 +29,7 @@ const EquationPreview = styled.aside`
   border-radius: ${themeVal('shape.rounded')};
   box-shadow: inset 0 0 0 1px ${themeVal('color.baseAlphaD')};
   margin-top: ${glsp()};
+  margin-bottom: ${glsp()};
 
   &::before {
     ${collecticon('triangle-up')}
@@ -92,6 +98,7 @@ export default function EquationEditor(props) {
   const equationBlockRef = useRef();
   const [isTooLong, setTooLong] = useState(false);
   const [latexEquation, setLatexEquation] = useState(equation);
+  const textareaRef = useRef(null);
 
   useEffect(() => {
     const node = equationBlockRef.current;
@@ -102,6 +109,12 @@ export default function EquationEditor(props) {
     }
   }, [latexEquation]);
 
+  useLayoutEffect(() => {
+    textareaRef.current.style.height = '1px';
+    const scrollHeight = textareaRef.current.scrollHeight;
+    textareaRef.current.style.height = `${scrollHeight}px`;
+  }, [latexEquation]);
+
   const handleInputChange = (e) => setLatexEquation(e.target.value);
   const handleSave = () => {
     const path = element && ReactEditor.findPath(editor, element);
@@ -110,14 +123,14 @@ export default function EquationEditor(props) {
 
   return (
     <>
-      <EquationInput spellCheck={false}>
-        <FormInput
-          id='equation'
-          name='equation'
-          value={latexEquation}
-          onChange={handleInputChange}
-        />
-      </EquationInput>
+      <FormTextarea
+        ref={textareaRef}
+        id='equation'
+        name='equation'
+        value={latexEquation}
+        onChange={handleInputChange}
+        spellCheck={false}
+      />
       <EquationPreview
         // Both contentEditable style and are needed for the click to work. See
         // more at:
@@ -139,9 +152,13 @@ export default function EquationEditor(props) {
           <BlockMath math={latexEquation} />
         </EquationPreviewBody>
       </EquationPreview>
-      <button type='button' onClick={handleSave}>
+      <Button
+        type='button'
+        variation='primary-raised-dark'
+        onClick={handleSave}
+      >
         Save equation
-      </button>
+      </Button>
     </>
   );
 }

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -127,23 +127,23 @@ export default function EquationEditor(props) {
     editor.simpleModal.show({ id: 'latex-modal' });
   };
 
-  const label = (
-    <>
-      Enter Latex code
-      <Button
-        type='button'
-        useIcon='circle-information'
-        hideText
-        onClick={showInfo}
-      >
-        Latex cheatsheet
-      </Button>
-    </>
-  );
-
   return (
     <>
-      <FormGroupStructure id='equation' label={label}>
+      <FormGroupStructure
+        id='equation'
+        label='Enter Latex code'
+        toolbarItems={
+          <Button
+            type='button'
+            useIcon='circle-information'
+            size='small'
+            hideText
+            onClick={showInfo}
+          >
+            Latex cheatsheet
+          </Button>
+        }
+      >
         <FormTextarea
           ref={textareaRef}
           id='equation'

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -8,7 +8,7 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { visuallyHidden } from '@devseed-ui/theme-provider';
 import { headingAlt } from '@devseed-ui/typography';
 import collecticon from '@devseed-ui/collecticons';
-import { FormLabel, FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
+import { FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
 import { Button } from '@devseed-ui/button';
 import { upsertEquation } from '.';
 import FormGroupStructure from '../../../common/forms/form-group-structure';

--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -11,6 +11,7 @@ import collecticon from '@devseed-ui/collecticons';
 import { FormLabel, FormTextarea as BaseFormTextarea } from '@devseed-ui/form';
 import { Button } from '@devseed-ui/button';
 import { upsertEquation } from '.';
+import FormGroupStructure from '../../../common/forms/form-group-structure';
 
 const EQUATION_PDF_THRESHOLD = 600;
 
@@ -126,27 +127,32 @@ export default function EquationEditor(props) {
     editor.simpleModal.show({ id: 'latex-modal' });
   };
 
+  const label = (
+    <>
+      Enter Latex code
+      <Button
+        type='button'
+        useIcon='circle-information'
+        hideText
+        onClick={showInfo}
+      >
+        Latex cheatsheet
+      </Button>
+    </>
+  );
+
   return (
     <>
-      <FormLabel id='equation'>
-        Enter Latex code
-        <Button
-          type='button'
-          useIcon='circle-information'
-          hideText
-          onClick={showInfo}
-        >
-          Latex cheatsheet
-        </Button>
-      </FormLabel>
-      <FormTextarea
-        ref={textareaRef}
-        id='equation'
-        name='equation'
-        value={latexEquation}
-        onChange={handleInputChange}
-        spellCheck={false}
-      />
+      <FormGroupStructure id='equation' label={label}>
+        <FormTextarea
+          ref={textareaRef}
+          id='equation'
+          name='equation'
+          value={latexEquation}
+          onChange={handleInputChange}
+          spellCheck={false}
+        />
+      </FormGroupStructure>
       <EquationPreview
         // Both contentEditable style and are needed for the click to work. See
         // more at:

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -5,17 +5,18 @@ import { Node, Transforms } from 'slate';
 import { ReactEditor, useSelected, useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
 
-import { themeVal } from '@devseed-ui/theme-provider';
+import { themeVal, rgba } from '@devseed-ui/theme-provider';
 
 const PreviewBody = styled.div`
   cursor: pointer;
   border: 1px solid;
   border-color: ${({ inFocus }) =>
-    inFocus ? themeVal('color.baseAlphaE') : 'transparent'};
+    inFocus ? themeVal('color.primary') : 'transparent'};
   border-radius: ${themeVal('shape.rounded')};
+  transition: border-color 0.24s ease 0s;
 
   &:hover {
-    border-color: ${themeVal('color.baseAlphaE')};
+    border-color: ${rgba(themeVal('color.primary'), 0.75)};
   }
 `;
 

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -15,8 +15,8 @@ function EquationElement(props) {
   const latexEquation = Node.string(element);
 
   const handleClick = useCallback(() => {
-    editor.equationModal.show({ latexEquation });
-  }, [editor, latexEquation]);
+    editor.equationModal.show({ element });
+  }, [editor, element]);
 
   return (
     <PreviewBody

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -2,14 +2,16 @@ import React, { useCallback } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { Node, Transforms } from 'slate';
-import { ReactEditor, useSlate } from 'slate-react';
+import { ReactEditor, useSelected, useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
 
 import { themeVal } from '@devseed-ui/theme-provider';
 
 const PreviewBody = styled.div`
   cursor: pointer;
-  border: 1px solid transparent;
+  border: 1px solid;
+  border-color: ${({ inFocus }) =>
+    inFocus ? themeVal('color.baseAlphaE') : 'transparent'};
   border-radius: ${themeVal('shape.rounded')};
 
   &:hover {
@@ -19,6 +21,7 @@ const PreviewBody = styled.div`
 
 function EquationElement(props) {
   const editor = useSlate();
+  const isSelected = useSelected();
   const { element, attributes, children } = props;
   const latexEquation = Node.string(element);
 
@@ -38,6 +41,7 @@ function EquationElement(props) {
         onClick={handleClick}
         contentEditable={false}
         style={{ userSelect: 'none' }}
+        inFocus={isSelected}
       >
         <BlockMath math={latexEquation || 'latex~empty~equation'} />
       </PreviewBody>

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import T from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Node, Transforms } from 'slate';
 import { ReactEditor, useSelected, useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
@@ -10,14 +10,21 @@ import { themeVal, rgba } from '@devseed-ui/theme-provider';
 const PreviewBody = styled.div`
   cursor: pointer;
   border: 1px solid;
-  border-color: ${({ inFocus }) =>
-    inFocus ? themeVal('color.primary') : 'transparent'};
   border-radius: ${themeVal('shape.rounded')};
   transition: border-color 0.24s ease 0s;
 
-  &:hover {
-    border-color: ${rgba(themeVal('color.primary'), 0.75)};
-  }
+  ${({ inFocus }) =>
+    inFocus
+      ? css`
+          border-color: ${rgba(themeVal('color.primary'), 0.48)};
+        `
+      : css`
+          border-color: transparent;
+
+          &:hover {
+            border-color: ${rgba(themeVal('color.primary'), 0.24)};
+          }
+        `}
 `;
 
 function EquationElement(props) {

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -5,8 +5,16 @@ import { Node, Transforms } from 'slate';
 import { ReactEditor, useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
 
+import { themeVal } from '@devseed-ui/theme-provider';
+
 const PreviewBody = styled.div`
   cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: ${themeVal('shape.rounded')};
+
+  &:hover {
+    border-color: ${themeVal('color.baseAlphaE')};
+  }
 `;
 
 function EquationElement(props) {
@@ -29,7 +37,7 @@ function EquationElement(props) {
       <PreviewBody
         onClick={handleClick}
         contentEditable={false}
-        style={{ userSelect: 'none', cursor: 'pointer' }}
+        style={{ userSelect: 'none' }}
       >
         <BlockMath math={latexEquation || 'latex~empty~equation'} />
       </PreviewBody>

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import T from 'prop-types';
+import styled from 'styled-components';
+import { Node } from 'slate';
+import { BlockMath } from 'react-katex';
+
+const PreviewBody = styled.div`
+  cursor: pointer;
+`;
+
+function EquationElement(props) {
+  const { element } = props;
+  const latexEquation = Node.string(element);
+
+  return (
+    <PreviewBody>
+      <BlockMath math={latexEquation || 'latex~empty~equation'} />
+    </PreviewBody>
+  );
+}
+
+EquationElement.propTypes = {
+  element: T.object.isRequired
+};
+
+export default EquationElement;

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
 import { Node } from 'slate';
+import { useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
 
 const PreviewBody = styled.div`
@@ -9,11 +10,20 @@ const PreviewBody = styled.div`
 `;
 
 function EquationElement(props) {
+  const editor = useSlate();
   const { element } = props;
   const latexEquation = Node.string(element);
 
+  const handleClick = useCallback(() => {
+    editor.equationModal.show({ latexEquation });
+  }, [editor, latexEquation]);
+
   return (
-    <PreviewBody>
+    <PreviewBody
+      onClick={handleClick}
+      contentEditable={false}
+      style={{ userSelect: 'none', cursor: 'pointer' }}
+    >
       <BlockMath math={latexEquation || 'latex~empty~equation'} />
     </PreviewBody>
   );

--- a/app/assets/scripts/components/slate/plugins/equation/equation-element.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-element.js
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
-import { Node } from 'slate';
-import { useSlate } from 'slate-react';
+import { Node, Transforms } from 'slate';
+import { ReactEditor, useSlate } from 'slate-react';
 import { BlockMath } from 'react-katex';
 
 const PreviewBody = styled.div`
@@ -11,26 +11,37 @@ const PreviewBody = styled.div`
 
 function EquationElement(props) {
   const editor = useSlate();
-  const { element } = props;
+  const { element, attributes, children } = props;
   const latexEquation = Node.string(element);
 
   const handleClick = useCallback(() => {
-    editor.equationModal.show({ element });
+    const path = element && ReactEditor.findPath(editor, element);
+    const offset = element.children[0].text.length;
+
+    Transforms.select(editor, {
+      anchor: { path, offset: 0 },
+      focus: { path, offset }
+    });
   }, [editor, element]);
 
   return (
-    <PreviewBody
-      onClick={handleClick}
-      contentEditable={false}
-      style={{ userSelect: 'none', cursor: 'pointer' }}
-    >
-      <BlockMath math={latexEquation || 'latex~empty~equation'} />
-    </PreviewBody>
+    <div {...attributes}>
+      <PreviewBody
+        onClick={handleClick}
+        contentEditable={false}
+        style={{ userSelect: 'none', cursor: 'pointer' }}
+      >
+        <BlockMath math={latexEquation || 'latex~empty~equation'} />
+      </PreviewBody>
+      <div>{children}</div>
+    </div>
   );
 }
 
 EquationElement.propTypes = {
-  element: T.object.isRequired
+  element: T.object.isRequired,
+  attributes: T.object.isRequired,
+  children: T.object.isRequired
 };
 
 export default EquationElement;

--- a/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
@@ -18,7 +18,7 @@ export function EquationModal() {
       size='large'
       revealed={visible}
       onCloseClick={closeModal}
-      title='Equation'
+      title='Edit Equation'
       content={<EquationEditor element={element} />}
     />
   );

--- a/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
@@ -6,12 +6,7 @@ import EquationEditor from './equation-editor';
 
 export function EquationModal() {
   const editor = useSlate();
-  const { visible, selection, equation } = editor.equationModal.getData();
-
-  const element = {
-    type: 'equation',
-    children: [{ text: 'latex~example: e=mc^2' }]
-  };
+  const { visible, element } = editor.equationModal.getData();
 
   const closeModal = useCallback(() => {
     editor.equationModal.reset();
@@ -24,7 +19,7 @@ export function EquationModal() {
       revealed={visible}
       onCloseClick={closeModal}
       title='Equation'
-      content={<EquationEditor element={element} equation={equation} />}
+      content={<EquationEditor element={element} />}
     />
   );
 }

--- a/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
@@ -1,0 +1,30 @@
+import React, { useCallback } from 'react';
+import { useSlate } from 'slate-react';
+
+import { Modal } from '@devseed-ui/modal';
+import EquationEditor from './equation-editor';
+
+export function EquationModal() {
+  const editor = useSlate();
+  const { visible, selection, equation } = editor.equationModal.getData();
+
+  const element = {
+    type: 'equation',
+    children: [{ text: 'latex~example: e=mc^2' }]
+  };
+
+  const closeModal = useCallback(() => {
+    editor.equationModal.reset();
+  }, [editor]);
+
+  return (
+    <Modal
+      id='modal'
+      size='large'
+      revealed={visible}
+      onCloseClick={closeModal}
+      title='Equation'
+      content={<EquationEditor element={element} equation={equation} />}
+    />
+  );
+}

--- a/app/assets/scripts/components/slate/plugins/equation/index.js
+++ b/app/assets/scripts/components/slate/plugins/equation/index.js
@@ -4,7 +4,8 @@ import castArray from 'lodash.castarray';
 import { getAbove, getRenderElement } from '@udecode/slate-plugins';
 
 import { getPathForRootBlockInsert, modKey } from '../common/utils';
-import EquationEditor from './equation-editor';
+// import EquationEditor from './equation-editor';
+import EquationElement from './equation-element';
 import { isFocusedAnd } from '../common/is-focused-compose';
 import { isInNodeType } from '../common/is-node-type';
 
@@ -75,7 +76,7 @@ export const EquationPlugin = {
   name: 'LaTeX equation',
   renderElement: getRenderElement({
     type: EQUATION,
-    component: EquationEditor
+    component: EquationElement
   }),
   onKeyDown: (e, editor) => {
     castArray(EquationPlugin.toolbar).forEach((btn) => {

--- a/app/assets/scripts/components/slate/plugins/equation/index.js
+++ b/app/assets/scripts/components/slate/plugins/equation/index.js
@@ -4,7 +4,6 @@ import castArray from 'lodash.castarray';
 import { getAbove, getRenderElement } from '@udecode/slate-plugins';
 
 import { getPathForRootBlockInsert, modKey } from '../common/utils';
-// import EquationEditor from './equation-editor';
 import EquationElement from './equation-element';
 import { isFocusedAnd } from '../common/is-focused-compose';
 import { isInNodeType } from '../common/is-node-type';
@@ -70,24 +69,26 @@ export const upsertEquation = (editor, equation, nodePath) => {
  */
 export const onEquationUse = (editor, btnId) => {
   const selection = editor.selection;
-  editor.equationModal.show({ selection });
 
-  // editor.referenceModal.show({ selection });
-  // switch (btnId) {
-  //   case 'equation':
-  //     upsertEquation(editor);
-  //     break;
-  //   case 'delete-equation':
-  //     deleteEquation(editor);
-  //     break;
-  //   case 'info-latex':
-  //     editor.simpleModal.show({ id: 'latex-modal' });
-  //     break;
-  // }
+  switch (btnId) {
+    case 'equation':
+      editor.equationModal.show({ selection });
+      break;
+    case 'edit-equation':
+      editor.equationModal.show({ selection });
+      break;
+    case 'delete-equation':
+      deleteEquation(editor);
+      break;
+    case 'info-latex':
+      editor.simpleModal.show({ id: 'latex-modal' });
+      break;
+  }
 };
 
 // Plugin definition for slate-plugins framework.
 export const EquationPlugin = {
+  voidTypes: [EQUATION],
   name: 'LaTeX equation',
   renderElement: getRenderElement({
     type: EQUATION,
@@ -122,6 +123,14 @@ export const EquationPlugin = {
       hotkey: 'mod+Shift+I',
       label: 'LaTeX cheatsheet',
       tip: (key) => `LaTeX cheatsheet (${modKey(key)})`,
+      isInContext: isFocusedAnd(isInEquation)
+    },
+    {
+      id: 'edit-equation',
+      icon: 'pencil',
+      hotkey: 'mod+Shift+E',
+      label: 'Edit equation',
+      tip: (key) => `Edit equation (${modKey(key)})`,
       isInContext: isFocusedAnd(isInEquation)
     },
     {

--- a/app/assets/scripts/components/slate/plugins/equation/index.js
+++ b/app/assets/scripts/components/slate/plugins/equation/index.js
@@ -80,9 +80,6 @@ export const onEquationUse = (editor, btnId) => {
     case 'delete-equation':
       deleteEquation(editor);
       break;
-    case 'info-latex':
-      editor.simpleModal.show({ id: 'latex-modal' });
-      break;
   }
 };
 
@@ -117,14 +114,6 @@ export const EquationPlugin = {
     tip: (key) => `Equation (${modKey(key)})`
   },
   contextToolbar: [
-    {
-      id: 'info-latex',
-      icon: 'circle-information',
-      hotkey: 'mod+Shift+I',
-      label: 'LaTeX cheatsheet',
-      tip: (key) => `LaTeX cheatsheet (${modKey(key)})`,
-      isInContext: isFocusedAnd(isInEquation)
-    },
     {
       id: 'edit-equation',
       icon: 'pencil',

--- a/app/assets/scripts/components/slate/plugins/equation/index.js
+++ b/app/assets/scripts/components/slate/plugins/equation/index.js
@@ -9,6 +9,9 @@ import EquationElement from './equation-element';
 import { isFocusedAnd } from '../common/is-focused-compose';
 import { isInNodeType } from '../common/is-node-type';
 
+export * from './equation-modal';
+export * from './with-equation-modal';
+
 // Plugin type.
 export const EQUATION = 'equation';
 
@@ -58,17 +61,25 @@ export const insertEquation = (editor) => {
  * @param {String} btnId The button that triggered the use.
  */
 export const onEquationUse = (editor, btnId) => {
-  switch (btnId) {
-    case 'equation':
-      insertEquation(editor);
-      break;
-    case 'delete-equation':
-      deleteEquation(editor);
-      break;
-    case 'info-latex':
-      editor.simpleModal.show({ id: 'latex-modal' });
-      break;
-  }
+  const selection = editor.selection;
+  Transforms.deselect(editor);
+  editor.equationModal.show({
+    selection,
+    latexEquation: 'latex~example: e=mc^2'
+  });
+
+  // editor.referenceModal.show({ selection });
+  // switch (btnId) {
+  //   case 'equation':
+  //     insertEquation(editor);
+  //     break;
+  //   case 'delete-equation':
+  //     deleteEquation(editor);
+  //     break;
+  //   case 'info-latex':
+  //     editor.simpleModal.show({ id: 'latex-modal' });
+  //     break;
+  // }
 };
 
 // Plugin definition for slate-plugins framework.

--- a/app/assets/scripts/components/slate/plugins/equation/index.js
+++ b/app/assets/scripts/components/slate/plugins/equation/index.js
@@ -43,15 +43,23 @@ const deleteEquation = (editor) => {
  *
  * @param {Editor} editor Slate editor instance.
  */
-export const insertEquation = (editor) => {
+export const upsertEquation = (editor, equation, nodePath) => {
   const node = {
     type: EQUATION,
-    children: [{ text: 'latex~example: e=mc^2' }]
+    children: [{ text: equation }]
   };
 
-  const path = getPathForRootBlockInsert(editor);
-  Transforms.insertNodes(editor, node, { at: path });
-  Transforms.select(editor, path);
+  if (nodePath) {
+    Transforms.removeNodes(editor, { at: nodePath });
+    Transforms.insertNodes(editor, node, { at: nodePath });
+  } else {
+    const { selection } = editor.equationModal.getData();
+    Transforms.select(editor, selection);
+
+    const path = getPathForRootBlockInsert(editor);
+    Transforms.insertNodes(editor, node, { at: path });
+    Transforms.select(editor, path);
+  }
 };
 
 /**
@@ -62,16 +70,12 @@ export const insertEquation = (editor) => {
  */
 export const onEquationUse = (editor, btnId) => {
   const selection = editor.selection;
-  Transforms.deselect(editor);
-  editor.equationModal.show({
-    selection,
-    latexEquation: 'latex~example: e=mc^2'
-  });
+  editor.equationModal.show({ selection });
 
   // editor.referenceModal.show({ selection });
   // switch (btnId) {
   //   case 'equation':
-  //     insertEquation(editor);
+  //     upsertEquation(editor);
   //     break;
   //   case 'delete-equation':
   //     deleteEquation(editor);

--- a/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
@@ -59,11 +59,17 @@ export const withEquationModal = (editor) => {
       case 'show': {
         // Use the data from the operation's args to do things. In this case to
         // make the equation modal visible.
-        const { selection, element } = args[0];
+        const { selection } = args[0];
+
+        const path = [...selection.anchor.path];
+        const element = path.slice(0, -1).reduce((path, index) => {
+          return path.children[index];
+        }, editor);
+
         equationModalDataRef.current = {
           visible: true,
           selection,
-          element
+          element: element.type === 'equation' ? element : null
         };
         break;
       }

--- a/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
@@ -1,0 +1,87 @@
+import { createOp } from '../common/create-change-operation';
+
+const equationModalInitialState = {
+  // Store whether the Modal is visible.
+  visible: false,
+  // Editor selection at the time the equation modal is displayed. When the
+  // equation modal is shown, the slate editor loses focus. Once the equation
+  // insertion is confirmed we need to know what the user had selected to know
+  // where to insert the equation.
+  selection: null,
+  equation: 'latex~empty~equation'
+};
+
+/**
+ * Enhances the slate editor with support for the equation modal and
+ * normalization.
+ *
+ * @param {Editor} editor The slate editor.
+ */
+export const withEquationModal = (editor) => {
+  // Store the data in a scoped ref so it is not exposed in the slate editor.
+  const equationModalDataRef = { current: equationModalInitialState };
+
+  // Add the equationModal.
+  editor.equationModal = {
+    // Store the operation to be applied on the next onChange cycle.
+    operation: createOp(),
+    reset: () => {
+      editor.equationModal.operation = createOp('reset');
+      // Trigger a change event.
+      editor.onChange();
+    },
+    show: (data) => {
+      // Create an operation, storing some data to be used later.
+      editor.equationModal.operation = createOp('show', {
+        selection: data.selection,
+        equation: data.latexEquation
+      });
+      // Trigger a change event.
+      editor.onChange();
+    },
+    getData: () => {
+      return equationModalDataRef.current;
+    }
+  };
+
+  // Handler for the equations modal operations.
+  // If an operation is handled, it should return true. This signals the
+  // onChange cycle that we're done and moves to the next one.
+  const handleEquationModalOperation = (editor) => {
+    const { type, args } = editor.equationModal.operation;
+    // If there's nothing to handle, just return.
+    if (!type) return false;
+
+    switch (type) {
+      case 'reset':
+        equationModalDataRef.current = equationModalDataRef;
+        break;
+      case 'show': {
+        // Use the data from the operation's args to do things. In this case to
+        // make the equation modal visible.
+        const { selection, equation } = args[0];
+        equationModalDataRef.current = {
+          visible: true,
+          selection,
+          equation
+        };
+        break;
+      }
+    }
+
+    // Since the operation was handled, clean it up.
+    editor.referenceModal.operation = createOp();
+    return true;
+  };
+
+  const { onChange } = editor;
+  // Enhance the slate editor's onChange method to include the equationModal
+  // operation handling.
+  editor.onChange = () => {
+    // Handle equationModal as first thing.
+    handleEquationModalOperation(editor);
+    return onChange();
+  };
+
+  return editor;
+};

--- a/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/with-equation-modal.js
@@ -8,7 +8,7 @@ const equationModalInitialState = {
   // insertion is confirmed we need to know what the user had selected to know
   // where to insert the equation.
   selection: null,
-  equation: 'latex~empty~equation'
+  element: null
 };
 
 /**
@@ -34,7 +34,7 @@ export const withEquationModal = (editor) => {
       // Create an operation, storing some data to be used later.
       editor.equationModal.operation = createOp('show', {
         selection: data.selection,
-        equation: data.latexEquation
+        element: data.element
       });
       // Trigger a change event.
       editor.onChange();
@@ -59,11 +59,11 @@ export const withEquationModal = (editor) => {
       case 'show': {
         // Use the data from the operation's args to do things. In this case to
         // make the equation modal visible.
-        const { selection, equation } = args[0];
+        const { selection, element } = args[0];
         equationModalDataRef.current = {
           visible: true,
           selection,
-          equation
+          element
         };
         break;
       }


### PR DESCRIPTION
Resolves [#501](https://github.com/NASA-IMPACT/nasa-apt/issues/501)

Refactors equation editing so the editor form is shown in a modal

- Adds a new option 'edit' to the context menu, clicking the button will open the equation editor in a modal
- Removes to cheatsheet link from the context menu and moves it into the modal