### PR TITLE
Show recover-data toast only once; automatically remove when user changes form data

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/local-store/index.js
+++ b/app/assets/scripts/components/documents/single-edit/local-store/index.js
@@ -11,29 +11,52 @@ import RecoverToast from './recover-toast';
 
 export function LocalStore({ atbd }) {
   const isInitialized = useRef();
+  const toastId = useRef();
   const { values, setValues, dirty } = useFormikContext();
   const { step } = useParams();
 
   const stepId = step || 'identifying_information';
-  const [displayRecoverToast, setDisplayRecoverToast] = useState(false);
   const [isOutDated, setIsOutDated] = useState(false);
+
+  const removeToast = useCallback(() => {
+    toast.dismiss(toastId.current);
+    toastId.current = null;
+  }, []);
 
   const recoverData = useCallback(() => {
     const localAtbdStorage = new LocalAtbdStorage();
     const localValues = localAtbdStorage.getAtbd(atbd, stepId);
     setValues(defaultsDeep(localValues, values));
-    setDisplayRecoverToast(false);
-  }, [atbd, values, setValues, stepId]);
+    removeToast();
+  }, [atbd, values, setValues, stepId, removeToast]);
 
   const clearData = useCallback(() => {
     const localAtbdStorage = new LocalAtbdStorage();
     localAtbdStorage.removeAtbd(atbd, stepId);
-    setDisplayRecoverToast(false);
-  }, [atbd, stepId]);
+    removeToast();
+  }, [atbd, stepId, removeToast]);
+
+  const showToast = useCallback(() => {
+    if (!toastId.current) {
+      toastId.current = toast.info(
+        <RecoverToast
+          recoverData={recoverData}
+          clearData={clearData}
+          closeToast={removeToast}
+          dataIsOutdated={isOutDated}
+        />,
+        {
+          autoClose: false,
+          closeButton: false
+        }
+      );
+    }
+  }, [clearData, recoverData, isOutDated, removeToast]);
 
   useEffect(() => {
     const localAtbdStorage = new LocalAtbdStorage();
     if (isInitialized.current) {
+      removeToast();
       if (dirty) {
         localAtbdStorage.setAtbd(atbd, stepId, values);
       } else {
@@ -44,32 +67,13 @@ export function LocalStore({ atbd }) {
         const localValues = localAtbdStorage.getAtbd(atbd, stepId);
         if (localValues) {
           const atdbUpdated = new Date(atbd.last_updated_at).getTime();
-          setDisplayRecoverToast(true);
+          showToast();
           setIsOutDated(localValues.created < atdbUpdated);
         }
         isInitialized.current = true;
       }
     }
-  }, [atbd, stepId, values, setValues, dirty]);
-
-  useEffect(() => {
-    if (displayRecoverToast) {
-      toast.info(
-        ({ closeToast }) => (
-          <RecoverToast
-            recoverData={recoverData}
-            clearData={clearData}
-            closeToast={closeToast}
-            dataIsOutdated={isOutDated}
-          />
-        ),
-        {
-          autoClose: false,
-          closeButton: false
-        }
-      );
-    }
-  }, [displayRecoverToast, isOutDated, clearData, recoverData]);
+  }, [atbd, stepId, values, setValues, dirty, showToast, removeToast]);
 
   return null;
 }


### PR DESCRIPTION
Fixes https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/363

If the user doesn't close the recover-data toast, the toast is displayed on every change event within the pages leading to several toast being shown on the page. 

Changes to fix:

- We're tracking the ID of the toast that is currently shown and only display a new toast of the toastID is falsy. 
- We're clearing the toastID once the toast has been hidden. 

Additionally:

- We're hiding the toast once the user starts changing the form. At this point, if the use recovers the data, the changes will be overwritten. This change assumes that the user does not want to recover the data once they start changing the data. @aboydnw let me know what you think of this. 