### PR TITLE
Exclude tables and images from abstract field

### DIFF
--- a/app/assets/scripts/components/common/forms/input-editor.js
+++ b/app/assets/scripts/components/common/forms/input-editor.js
@@ -17,7 +17,7 @@ import { RichTextEditor, InlineRichTextEditor } from '../../slate';
  * @prop {string} description Field description shown in a tooltip
  * @prop {node} helper Helper message shown below input.
  */
-export function FormikInputEditor({ helper, id, ...props }) {
+export function FormikInputEditor({ helper, id, excludePlugins, ...props }) {
   return (
     <FastField {...props}>
       {({ field, meta, form }) => {
@@ -40,6 +40,7 @@ export function FormikInputEditor({ helper, id, ...props }) {
                 form.setFieldValue(field.name, value);
                 form.setFieldTouched(field.name);
               }}
+              excludePlugins={excludePlugins}
             />
           </FormGroupStructure>
         );
@@ -50,7 +51,12 @@ export function FormikInputEditor({ helper, id, ...props }) {
 
 FormikInputEditor.propTypes = {
   id: T.string,
-  helper: T.node
+  helper: T.node,
+  excludePlugins: T.array
+};
+
+FormikInputEditor.defaultProps = {
+  excludePlugins: []
 };
 
 /**

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -17,6 +17,11 @@ import { formString } from '../../../../utils/strings';
 import { getDocumentSectionLabel } from '../sections';
 import { LocalStore } from '../local-store';
 
+import { ImageBlockPlugin } from '../../../slate/plugins/image';
+import { TableBlockPlugin } from '../../../slate/plugins/table';
+
+const exlcudePlugins = [ImageBlockPlugin, TableBlockPlugin];
+
 export default function StepCloseout(props) {
   const {
     renderInpageHeader,
@@ -126,6 +131,7 @@ function FieldAbstract() {
       label='Short ATBD summary'
       description={formString('closeout.abstract')}
       growWithContents
+      excludePlugins={exlcudePlugins}
       helper={
         <FormHelperCounter
           value={words}

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -19,8 +19,9 @@ import { LocalStore } from '../local-store';
 
 import { ImageBlockPlugin } from '../../../slate/plugins/image';
 import { TableBlockPlugin } from '../../../slate/plugins/table';
+import { SubSectionPlugin } from '../../../slate/plugins/subsection';
 
-const exlcudePlugins = [ImageBlockPlugin, TableBlockPlugin];
+const exlcudePlugins = [ImageBlockPlugin, TableBlockPlugin, SubSectionPlugin];
 
 export default function StepCloseout(props) {
   const {

--- a/app/assets/scripts/components/slate/editor.js
+++ b/app/assets/scripts/components/slate/editor.js
@@ -120,8 +120,17 @@ const withPlugins = [
 const HEADER_HEIGHT = 92;
 
 export function RichTextEditor(props) {
-  const { id, onChange: inputOnChange, value: inputVal } = props;
+  const {
+    id,
+    onChange: inputOnChange,
+    value: inputVal,
+    excludePlugins
+  } = props;
   const editor = useMemo(() => pipe(createEditor(), ...withPlugins), []);
+
+  const usePlugins = useMemo(() => {
+    return plugins.filter((plugin) => !excludePlugins.includes(plugin));
+  }, [excludePlugins]);
 
   // The editor needs to work with an array, but we store the value as an object
   // which is the first and only child.
@@ -140,17 +149,17 @@ export function RichTextEditor(props) {
           boundaryElement='[data-sticky="boundary"]'
           hideOnBoundaryHit={false}
         >
-          <EditorToolbar plugins={plugins} />
+          <EditorToolbar plugins={usePlugins} />
         </StickyElement>
-        <EditorFloatingToolbar plugins={plugins} />
+        <EditorFloatingToolbar plugins={usePlugins} />
         <EditorLinkToolbar />
         <ReferencesModal />
-        <ShortcutsModal plugins={plugins} />
+        <ShortcutsModal plugins={usePlugins} />
         <LatexModal />
 
         <EditableDebug
           id={id}
-          plugins={plugins}
+          plugins={usePlugins}
           value={value}
           onDebugChange={onChange}
         />
@@ -162,7 +171,12 @@ export function RichTextEditor(props) {
 RichTextEditor.propTypes = {
   id: T.string,
   onChange: T.func,
-  value: T.object
+  value: T.object,
+  excludePlugins: T.array
+};
+
+RichTextEditor.defaultProps = {
+  excludePlugins: []
 };
 
 export function ReadEditor(props) {


### PR DESCRIPTION
Following the discussions in https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/364 we're removing the table and image plugins from the abstract field. 

- Adds new prop `excludePlugins` from `FormikInputEditor` and `RichTextEditor` which allows passing along an array of Slate plugins that should not be available to the instance.
- Extends `RichTextEditor` so plugins passed with `excludePlugins` are excluded
- Exclude table and image plugins from `FieldAbstract`