### PR TITLE
Add warning before closing form with unsaved changes

### DIFF
--- a/app/assets/scripts/components/common/unload-prompt.js
+++ b/app/assets/scripts/components/common/unload-prompt.js
@@ -1,0 +1,53 @@
+import React, { useCallback, useEffect } from 'react';
+import T from 'prop-types';
+import { Prompt } from 'react-router-dom';
+import { useFormikContext } from 'formik';
+
+const DEFAULT_WARNING =
+  'Are you sure you want to leave? Unsaved changes will be lost.';
+
+export function UnloadPrompt({ when, message }) {
+  const beforeunloadHandler = useCallback(
+    (event) => {
+      event.preventDefault();
+      return (event.returnValue = message);
+    },
+    [message]
+  );
+
+  useEffect(() => {
+    if (when) {
+      window.addEventListener('beforeunload', beforeunloadHandler);
+    } else {
+      window.removeEventListener('beforeunload', beforeunloadHandler);
+    }
+
+    return () =>
+      window.removeEventListener('beforeunload', beforeunloadHandler);
+  }, [when, beforeunloadHandler]);
+
+  return <Prompt when={when} message={message} />;
+}
+
+UnloadPrompt.propTypes = {
+  when: T.bool.isRequired,
+  message: T.string
+};
+
+UnloadPrompt.defaultProps = {
+  message: DEFAULT_WARNING
+};
+
+export function FormikUnloadPrompt({ message }) {
+  const { dirty } = useFormikContext();
+
+  return <UnloadPrompt when={dirty} message={message} />;
+}
+
+FormikUnloadPrompt.propTypes = {
+  message: T.string
+};
+
+FormikUnloadPrompt.defaultProps = {
+  message: DEFAULT_WARNING
+};

--- a/app/assets/scripts/components/documents/single-edit/step-algo-description.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-description.js
@@ -23,6 +23,7 @@ import { formString } from '../../../utils/strings';
 import { editorEmptyValue } from '../../slate';
 import { getDocumentSectionLabel } from './sections';
 import { LocalStore } from './local-store';
+import { FormikUnloadPrompt } from '../../common/unload-prompt';
 
 const DeletableFieldsetTriptych = styled(DeletableFieldset)`
   ${FormFieldsetBody} {
@@ -63,6 +64,7 @@ export default function StepAlgoDescription(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-implementation.js
@@ -18,6 +18,7 @@ import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
 import { LocalStore } from './local-store';
+import { FormikUnloadPrompt } from '../../common/unload-prompt';
 
 // The initial value is the same for
 // Algorithm Implementations
@@ -54,6 +55,7 @@ export default function StepAlgoImplementation(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
+++ b/app/assets/scripts/components/documents/single-edit/step-algo-usage.js
@@ -14,6 +14,7 @@ import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
 import { LocalStore } from './local-store';
+import { FormikUnloadPrompt } from '../../common/unload-prompt';
 
 export default function StepAlgoUsage(props) {
   const {
@@ -40,6 +41,7 @@ export default function StepAlgoUsage(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-closeout/index.js
@@ -16,6 +16,7 @@ import { useSubmitForVersionData } from '../use-submit';
 import { formString } from '../../../../utils/strings';
 import { getDocumentSectionLabel } from '../sections';
 import { LocalStore } from '../local-store';
+import { FormikUnloadPrompt } from '../../../common/unload-prompt';
 
 export default function StepCloseout(props) {
   const {
@@ -48,6 +49,7 @@ export default function StepCloseout(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-contacts/index.js
@@ -22,6 +22,7 @@ import { validateContact } from '../../../contacts/contact-utils';
 import { getDocumentSectionLabel } from '../sections';
 import { documentEdit } from '../../../../utils/url-creator';
 import { LocalStore } from '../local-store';
+import { FormikUnloadPrompt } from '../../../common/unload-prompt';
 
 export default function StepContacts(props) {
   const {
@@ -102,6 +103,7 @@ export default function StepContacts(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         {contacts.status === 'loading' && <GlobalLoading />}
         {contacts.status === 'succeeded' && (

--- a/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
+++ b/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
@@ -21,6 +21,7 @@ import { useSubmitForMetaAndVersionData } from './use-submit';
 import { getDocumentSectionLabel } from './sections';
 import { isPublished } from '../status';
 import { LocalStore } from './local-store';
+import { FormikUnloadPrompt } from '../../common/unload-prompt';
 
 export default function StepIdentifyingInformation(props) {
   const {
@@ -67,6 +68,7 @@ export default function StepIdentifyingInformation(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-introduction.js
+++ b/app/assets/scripts/components/documents/single-edit/step-introduction.js
@@ -14,6 +14,7 @@ import { useSubmitForVersionData } from './use-submit';
 import { formString } from '../../../utils/strings';
 import { getDocumentSectionLabel } from './sections';
 import { LocalStore } from './local-store';
+import { FormikUnloadPrompt } from '../../common/unload-prompt';
 
 export default function StepIntroduction(props) {
   const {
@@ -40,6 +41,7 @@ export default function StepIntroduction(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>

--- a/app/assets/scripts/components/documents/single-edit/step-references/index.js
+++ b/app/assets/scripts/components/documents/single-edit/step-references/index.js
@@ -12,6 +12,7 @@ import { useSingleAtbd } from '../../../../context/atbds-list';
 import { useSubmitForVersionData } from '../use-submit';
 import { createDocumentReferenceIndex } from '../../../../utils/references';
 import { LocalStore } from '../local-store';
+import { FormikUnloadPrompt } from '../../../common/unload-prompt';
 
 export default function StepReferences(props) {
   const {
@@ -57,6 +58,7 @@ export default function StepReferences(props) {
     >
       <Inpage>
         <LocalStore atbd={atbd} />
+        <FormikUnloadPrompt />
         {renderInpageHeader()}
         <InpageBody>
           <FormBlock>


### PR DESCRIPTION
Implements https://github.com/NASA-IMPACT/nasa-apt/issues/455

- Adds two components
  - `UnloadPrompt` a generic unload prompt that can be plugged in anywhere and will show a confirmation prompt whenever the page changes or the browser is closed or reloaded
  - `FormikUnloadPrompt` uses the Formik context to set the `when` property of `UnloadPrompt`; can only be used within a Formik context
- Adds `FormikUnloadPrompt` to document editor forms