### PR TITLE
Equation modal normalization

### DIFF
--- a/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-editor.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
-import { Node } from 'slate';
 import { useEditor } from 'slate-react';
 import { BlockMath } from 'react-katex';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
@@ -14,12 +13,6 @@ import {
   FormCheckableGroup
 } from '@devseed-ui/form';
 import { Button } from '@devseed-ui/button';
-import {
-  insertEquation,
-  updateEquation,
-  deleteEquation,
-  isInlineEquation
-} from '.';
 import BaseFormGroupStructure from '../../../common/forms/form-group-structure';
 
 const EQUATION_PDF_THRESHOLD = 600;
@@ -105,25 +98,12 @@ const EquationPreviewBody = styled.div`
   }
 `;
 
-const FormFooter = styled.div`
-  margin-top: ${glsp(1)};
-  text-align: right;
-
-  & > button {
-    margin-left: ${glsp(0.5)};
-  }
-`;
-
 export default function EquationEditor(props) {
-  const { element } = props;
-  const equation = element ? Node.string(element) : 'latex~empty~equation';
+  const { isInline, latexEquation, onChange } = props;
+
   const editor = useEditor();
   const equationBlockRef = useRef();
   const [isTooLong, setTooLong] = useState(false);
-  const [latexEquation, setLatexEquation] = useState(equation);
-  const [isInline, setIsInline] = useState(
-    element ? isInlineEquation(element) : false
-  );
   const textareaRef = useRef(null);
 
   useEffect(() => {
@@ -141,27 +121,11 @@ export default function EquationEditor(props) {
     textareaRef.current.style.height = `${scrollHeight}px`;
   }, [latexEquation]);
 
-  const handleInputChange = (e) => setLatexEquation(e.target.value);
-  const handleSave = () => {
-    if (element) {
-      updateEquation(editor, latexEquation, isInline, element);
-    } else {
-      insertEquation(editor, latexEquation, isInline);
-    }
-    editor.equationModal.reset();
-  };
+  const handleInputChange = (e) =>
+    onChange({ equation: e.target.value, isInline });
 
   const showInfo = () => {
     editor.simpleModal.show({ id: 'latex-modal' });
-  };
-
-  const closeModal = () => {
-    editor.equationModal.reset();
-  };
-
-  const handleDelete = () => {
-    deleteEquation(editor);
-    closeModal();
   };
 
   return (
@@ -174,7 +138,9 @@ export default function EquationEditor(props) {
             type='radio'
             name='equation-type'
             id='equation-type-inline'
-            onChange={() => setIsInline(true)}
+            onChange={() => {
+              onChange({ equation: latexEquation, isInline: true });
+            }}
           >
             Inline
           </FormCheckable>
@@ -184,7 +150,9 @@ export default function EquationEditor(props) {
             type='radio'
             name='equation-type'
             id='equation-type-block'
-            onChange={() => setIsInline(false)}
+            onChange={() => {
+              onChange({ equation: latexEquation, isInline: false });
+            }}
           >
             Block
           </FormCheckable>
@@ -236,29 +204,12 @@ export default function EquationEditor(props) {
           <BlockMath math={latexEquation} />
         </EquationPreviewBody>
       </EquationPreview>
-
-      <FormFooter>
-        <Button type='button' useIcon='xmark--small' onClick={closeModal}>
-          Cancel
-        </Button>
-        {element && (
-          <Button type='button' useIcon='trash-bin' onClick={handleDelete}>
-            Delete
-          </Button>
-        )}
-        <Button
-          type='button'
-          variation='primary-raised-dark'
-          useIcon='tick--small'
-          onClick={handleSave}
-        >
-          {element ? 'Update' : 'Insert'}
-        </Button>
-      </FormFooter>
     </>
   );
 }
 
 EquationEditor.propTypes = {
-  element: T.object
+  isInline: T.bool,
+  latexEquation: T.string,
+  onChange: T.func
 };

--- a/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
@@ -1,16 +1,56 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useSlate } from 'slate-react';
+import { Node } from 'slate';
 
 import { Modal } from '@devseed-ui/modal';
+import { Button } from '@devseed-ui/button';
 import EquationEditor from './equation-editor';
+import {
+  deleteEquation,
+  insertEquation,
+  isInlineEquation,
+  updateEquation
+} from '.';
 
 export function EquationModal() {
   const editor = useSlate();
   const { visible, element } = editor.equationModal.getData();
 
+  const initEquation = element ? Node.string(element) : 'latex~empty~equation';
+  const initInline = element ? isInlineEquation(element) : false;
+
+  const [latexEquation, setLatexEquation] = useState(initEquation);
+  const [isInline, setIsInline] = useState(initInline);
+
+  // Reset on model open.
+  useEffect(() => visible && setLatexEquation(initEquation), [
+    visible,
+    initEquation
+  ]);
+  useEffect(() => visible && setIsInline(initInline), [visible, initInline]);
+
   const closeModal = useCallback(() => {
     editor.equationModal.reset();
   }, [editor]);
+
+  const onEquationEditorChange = useCallback(({ equation, isInline }) => {
+    setLatexEquation(equation);
+    setIsInline(isInline);
+  }, []);
+
+  const handleSave = () => {
+    if (element) {
+      updateEquation(editor, latexEquation, isInline, element);
+    } else {
+      insertEquation(editor, latexEquation, isInline);
+    }
+    closeModal();
+  };
+
+  const handleDelete = () => {
+    deleteEquation(editor);
+    closeModal();
+  };
 
   const title = `${element ? 'Edit' : 'Insert'} equation`;
 
@@ -21,7 +61,34 @@ export function EquationModal() {
       revealed={visible}
       onCloseClick={closeModal}
       title={title}
-      content={<EquationEditor element={element} />}
+      content={
+        <EquationEditor
+          hasEquation={!!element}
+          isInline={isInline}
+          latexEquation={latexEquation}
+          onChange={onEquationEditorChange}
+        />
+      }
+      footerContent={
+        <React.Fragment>
+          <Button type='button' useIcon='xmark--small' onClick={closeModal}>
+            Cancel
+          </Button>
+          {element && (
+            <Button type='button' useIcon='trash-bin' onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
+          <Button
+            type='button'
+            variation='primary-raised-dark'
+            useIcon='tick--small'
+            onClick={handleSave}
+          >
+            {element ? 'Update' : 'Insert'}
+          </Button>
+        </React.Fragment>
+      }
     />
   );
 }

--- a/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
+++ b/app/assets/scripts/components/slate/plugins/equation/equation-modal.js
@@ -71,14 +71,19 @@ export function EquationModal() {
       }
       footerContent={
         <React.Fragment>
-          <Button type='button' useIcon='xmark--small' onClick={closeModal}>
-            Cancel
-          </Button>
           {element && (
             <Button type='button' useIcon='trash-bin' onClick={handleDelete}>
               Delete
             </Button>
           )}
+          <Button
+            type='button'
+            variation='base-raised-light'
+            useIcon='xmark--small'
+            onClick={closeModal}
+          >
+            Cancel
+          </Button>
           <Button
             type='button'
             variation='primary-raised-dark'


### PR DESCRIPTION
This PR is set on top of #366 and normalizes the modal usage / reorders the buttons.

Although there was nothing wrong with the approach taken in #366, the button controls on APT have been set in the modal footer aligned to the left (or center in small modals). See for example the reference modal:
https://github.com/NASA-IMPACT/nasa-apt-frontend/blob/fec79ebc427a240be958b98b4a5a84d7120b3850/app/assets/scripts/components/slate/plugins/reference/reference-modal.js#L114-L130

To achieve this I had to move some of the logic out of `EquationEditor` and into the `EquationModal`. Because it changes some of your code I didn't want to add it directly to the other PR. See what you think. If you want to change stuff around or just use some of the code, feel free.
