### PR TITLE
Block simultaneous edit

### DIFF
--- a/app/assets/scripts/components/common/confirmation-prompt.js
+++ b/app/assets/scripts/components/common/confirmation-prompt.js
@@ -6,7 +6,7 @@ import { Button } from '@devseed-ui/button';
 import { headingAlt } from '@devseed-ui/typography';
 import { glsp } from '@devseed-ui/theme-provider';
 
-const ConfirmationModalFooter = styled(ModalFooter)`
+export const ConfirmationModalFooter = styled(ModalFooter)`
   justify-content: center;
 `;
 

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -4,6 +4,7 @@ import { useHistory } from 'react-router';
 
 import { Modal, ModalFooter } from '@devseed-ui/modal';
 import { Button } from '@devseed-ui/button';
+import { toast } from 'react-toastify';
 
 import { axiosAPI } from '../../../utils/axios';
 import { documentView } from '../../../utils/url-creator';
@@ -31,10 +32,16 @@ function CheckLock({ id, version, user }) {
 
   useEffect(() => {
     setLock(id, version, user.accessToken).catch((error) => {
-      setMessage(error.response.data.detail);
-      setShowModal(true);
+      const { status, data } = error.response;
+      if (status === 409) {
+        setMessage(data.detail);
+        setShowModal(true);
+      } else {
+        history.push(documentView(id, version));
+        toast.error('Unable to lock the ATBD version.');
+      }
     });
-  }, [id, version, user.accessToken]);
+  }, [id, version, user.accessToken, history]);
 
   const cancel = () => {
     setShowModal(false);
@@ -42,9 +49,15 @@ function CheckLock({ id, version, user }) {
   };
 
   const unlock = () => {
-    setLock(id, version, user.accessToken, 'unlock').then(() => {
-      setShowModal(false);
-    });
+    setLock(id, version, user.accessToken, 'unlock')
+      .then(() => {
+        setShowModal(false);
+      })
+      .catch(() => {
+        setShowModal(false);
+        history.push(documentView(id, version));
+        toast.error('Unable to unlock the ATBD version.');
+      });
   };
 
   return (

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -66,14 +66,14 @@ function CheckLock({ id, version, user }) {
       size='small'
       revealed={showModal}
       onCloseClick={cancel}
-      title='ATDB is locked'
+      title='Overwrite Other Changes?'
       content={
         <>
           <p>
-            {message} You can unlock this ATBD version and start editing but the
-            current editing user will loose their changes.
+            {message} If you continue, you will overwrite any changes they have
+            made.
           </p>
-          <p>Do you want to unlock the ATDB version?</p>
+          <p>We suggest verifying with them before continuing.</p>
         </>
       }
       renderFooter={() => (
@@ -84,7 +84,7 @@ function CheckLock({ id, version, user }) {
             useIcon='tick--small'
             onClick={unlock}
           >
-            Unlock
+            Continue &amp; Overwrite
           </Button>
           <Button
             type='button'

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import T from 'prop-types';
+
+import { Modal, ModalFooter } from '@devseed-ui/modal';
+import { Button } from '@devseed-ui/button';
+
+import { axiosAPI } from '../../../utils/axios';
+
+const checkLock = (alias, version, userToken) => {
+  const headers = userToken
+    ? {
+        headers: {
+          Authorization: `Bearer ${userToken}`
+        }
+      }
+    : {};
+
+  return axiosAPI({
+    url: `/atbds/${alias}/versions/${version}/lock`,
+    method: 'post',
+    ...headers
+  });
+};
+
+function CheckLock({ id, version, user }) {
+  const [showModal, setShowModal] = useState(false);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    checkLock(id, version, user.accessToken).catch((error) => {
+      setMessage(error.response.data.detail);
+      setShowModal(true);
+    });
+  }, [id, version, user.accessToken]);
+
+  return (
+    <Modal
+      id='modal'
+      size='small'
+      revealed={showModal}
+      // onCloseClick={onClose}
+      title='ATDB is locked'
+      content={
+        <>
+          <p>
+            {message} You can unlock this ATBD version and start editing but the
+            current editing user will loose their changes.
+          </p>
+          <p>Do you want to unlock the ATDB version?</p>
+        </>
+      }
+      renderFooter={() => (
+        <ModalFooter>
+          <Button
+            type='button'
+            variation='primary-raised-dark'
+            useIcon='tick--small'
+            onClick={() => {}}
+          >
+            Unlock
+          </Button>
+          <Button
+            type='button'
+            variation='base-raised-light'
+            useIcon='xmark--small'
+            onClick={() => {}}
+          >
+            Cancel
+          </Button>
+        </ModalFooter>
+      )}
+    />
+  );
+}
+
+CheckLock.propTypes = {
+  id: T.string.isRequired,
+  version: T.string.isRequired,
+  user: T.shape({
+    accessToken: T.string.isRequired
+  })
+};
+
+export default CheckLock;

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import T from 'prop-types';
+import { useHistory } from 'react-router';
 
 import { Modal, ModalFooter } from '@devseed-ui/modal';
 import { Button } from '@devseed-ui/button';
 
 import { axiosAPI } from '../../../utils/axios';
+import { documentView } from '../../../utils/url-creator';
 
 const checkLock = (alias, version, userToken) => {
   const headers = userToken
@@ -23,6 +25,7 @@ const checkLock = (alias, version, userToken) => {
 };
 
 function CheckLock({ id, version, user }) {
+  const history = useHistory();
   const [showModal, setShowModal] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -33,12 +36,17 @@ function CheckLock({ id, version, user }) {
     });
   }, [id, version, user.accessToken]);
 
+  const cancel = () => {
+    setShowModal(false);
+    history.push(documentView(id, version));
+  };
+
   return (
     <Modal
       id='modal'
       size='small'
       revealed={showModal}
-      // onCloseClick={onClose}
+      onCloseClick={cancel}
       title='ATDB is locked'
       content={
         <>
@@ -63,7 +71,7 @@ function CheckLock({ id, version, user }) {
             type='button'
             variation='base-raised-light'
             useIcon='xmark--small'
-            onClick={() => {}}
+            onClick={cancel}
           >
             Cancel
           </Button>

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -2,12 +2,16 @@ import React, { useEffect, useState } from 'react';
 import T from 'prop-types';
 import { useHistory } from 'react-router';
 
-import { Modal, ModalFooter } from '@devseed-ui/modal';
+import { Modal } from '@devseed-ui/modal';
 import { Button } from '@devseed-ui/button';
 import { toast } from 'react-toastify';
 
 import { axiosAPI } from '../../../utils/axios';
 import { documentView } from '../../../utils/url-creator';
+import {
+  ConfirmationModalProse,
+  ConfirmationModalFooter
+} from '../../common/confirmation-prompt';
 
 const setLock = (alias, version, userToken, actionConfig = {}) => {
   const methods = {
@@ -49,15 +53,17 @@ function CheckLock({ id, version, user }) {
       if (status === 423) {
         const { preferred_username } = data.detail.lock_owner;
         setMessage(
-          <>
+          <ConfirmationModalProse>
             <p>
-              {preferred_username} is currently editing this document. If you
-              continue, you will overwrite any changes they have made.
+              <strong>{preferred_username}</strong> is currently editing this
+              document. If you continue, you will overwrite any changes they
+              have made.
             </p>
             <p>
-              We suggest verifying with {preferred_username} before continuing.
+              We suggest verifying with <strong>{preferred_username}</strong>{' '}
+              before continuing.
             </p>
-          </>
+          </ConfirmationModalProse>
         );
         setShowModal(true);
       } else {
@@ -101,10 +107,11 @@ function CheckLock({ id, version, user }) {
       size='small'
       revealed={showModal}
       onCloseClick={cancel}
-      title='Overwrite Other Changes?'
+      closeButton={false}
+      title='Overwrite other changes?'
       content={message}
       renderFooter={() => (
-        <ModalFooter>
+        <ConfirmationModalFooter>
           <Button
             type='button'
             variation='primary-raised-dark'
@@ -121,7 +128,7 @@ function CheckLock({ id, version, user }) {
           >
             Cancel
           </Button>
-        </ModalFooter>
+        </ConfirmationModalFooter>
       )}
     />
   );

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -41,6 +41,11 @@ function CheckLock({ id, version, user }) {
         toast.error('Unable to lock the ATBD version.');
       }
     });
+
+    return () =>
+      setLock(id, version, user.accessToken, 'clearlock').catch(() => {
+        toast.error('Unable to clear lock of ATBD version. Please try again.');
+      });
   }, [id, version, user.accessToken, history]);
 
   const cancel = () => {

--- a/app/assets/scripts/components/documents/single-edit/check-lock.js
+++ b/app/assets/scripts/components/documents/single-edit/check-lock.js
@@ -8,7 +8,7 @@ import { Button } from '@devseed-ui/button';
 import { axiosAPI } from '../../../utils/axios';
 import { documentView } from '../../../utils/url-creator';
 
-const checkLock = (alias, version, userToken) => {
+const setLock = (alias, version, userToken, action = 'lock') => {
   const headers = userToken
     ? {
         headers: {
@@ -18,7 +18,7 @@ const checkLock = (alias, version, userToken) => {
     : {};
 
   return axiosAPI({
-    url: `/atbds/${alias}/versions/${version}/lock`,
+    url: `/atbds/${alias}/versions/${version}/${action}`,
     method: 'post',
     ...headers
   });
@@ -30,7 +30,7 @@ function CheckLock({ id, version, user }) {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
-    checkLock(id, version, user.accessToken).catch((error) => {
+    setLock(id, version, user.accessToken).catch((error) => {
       setMessage(error.response.data.detail);
       setShowModal(true);
     });
@@ -39,6 +39,12 @@ function CheckLock({ id, version, user }) {
   const cancel = () => {
     setShowModal(false);
     history.push(documentView(id, version));
+  };
+
+  const unlock = () => {
+    setLock(id, version, user.accessToken, 'unlock').then(() => {
+      setShowModal(false);
+    });
   };
 
   return (
@@ -63,7 +69,7 @@ function CheckLock({ id, version, user }) {
             type='button'
             variation='primary-raised-dark'
             useIcon='tick--small'
-            onClick={() => {}}
+            onClick={unlock}
           >
             Unlock
           </Button>

--- a/app/assets/scripts/components/documents/single-edit/index.js
+++ b/app/assets/scripts/components/documents/single-edit/index.js
@@ -35,6 +35,7 @@ import { useThreadStats } from '../../../context/threads-list';
 import { useEffectPrevious } from '../../../utils/use-effect-previous';
 import { useSaveTooltipPlacement } from '../../../utils/use-save-tooltip-placement';
 import { documentEdit, documentView } from '../../../utils/url-creator';
+import CheckLock from './check-lock';
 
 const FormFooter = styled.div`
   display: flex;
@@ -45,7 +46,7 @@ const FormFooter = styled.div`
 function DocumentEdit() {
   const { id, version, step } = useParams();
   const history = useHistory();
-  const { isLogged } = useUser();
+  const { isLogged, user } = useUser();
   const {
     atbd,
     fetchSingleAtbd,
@@ -80,7 +81,9 @@ function DocumentEdit() {
   );
 
   useEffect(() => {
-    isLogged && fetchSingleAtbd();
+    if (isLogged) {
+      fetchSingleAtbd();
+    }
   }, [isLogged, id, version, fetchSingleAtbd]);
 
   const { menuHandler, documentModalProps } = useDocumentModals({
@@ -179,6 +182,7 @@ function DocumentEdit() {
 
   return (
     <App pageTitle={pageTitle}>
+      <CheckLock id={id} version={version} user={user} />
       {atbd.status === 'loading' && <GlobalLoading />}
       {atbd.status === 'succeeded' && (
         <DocumentModals {...documentModalProps} />


### PR DESCRIPTION
Resolves https://github.com/NASA-IMPACT/nasa-apt/issues/454

Adds new component `CheckLog`, which encapsulates functionality to set locks on ATBD versions. 

- On mounting the component, checks if lock can set; redirects to version view if not.
- If the versions is locked, the a modal is shown, allowing authors to overwrite the lock. 
- On unmounting the component, clears the lock.
