### PR TITLE
Comment mentions

### DIFF
--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -196,8 +196,9 @@ const CommentForm = (props) => {
           }
         };
 
+        const notify = values.notify || [];
         const notifyValue = contributorsSelectOptions.filter(({ value }) =>
-          values.notify.includes(value)
+          notify.includes(value)
         );
 
         const handleNotifyChange = (values) => {

--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -216,6 +216,7 @@ const CommentForm = (props) => {
                   options={contributorsSelectOptions}
                   value={notifyValue}
                   onChange={handleNotifyChange}
+                  menuPlacement='top'
                 />
               </FormGroupStructure>
             )}

--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -104,27 +104,34 @@ const getTextareaLabel = ({ type, values, setFieldValue }) => {
   }
 };
 
-const getInitialValues = ({ type, section, comment, threadId, commentId }) => {
+const getInitialValues = ({
+  type,
+  section,
+  comment,
+  threadId,
+  commentId,
+  notify = []
+}) => {
   switch (type) {
     case 'new':
       return {
         section:
           !section || section === THREAD_SECTION_ALL ? 'general' : section,
         comment: '',
-        notify: []
+        notify
       };
     case 'reply':
       return {
         threadId,
         comment: '',
-        notify: []
+        notify
       };
     case 'edit':
       return {
         threadId,
         commentId,
         comment,
-        notify: []
+        notify
       };
 
     default:
@@ -139,6 +146,7 @@ const CommentForm = (props) => {
     initialSection,
     threadId,
     contributors,
+    defaultNotify,
     commentId,
     onSubmit,
     onCancel
@@ -161,9 +169,10 @@ const CommentForm = (props) => {
         comment,
         threadId,
         commentId,
-        section: initialSection
+        section: initialSection,
+        notify: defaultNotify
       }),
-    [type, comment, threadId, commentId, initialSection]
+    [type, comment, threadId, commentId, initialSection, defaultNotify]
   );
 
   const { user } = useUser();
@@ -255,6 +264,7 @@ CommentForm.propTypes = {
   type: T.oneOf(['new', 'reply', 'edit']),
   threadId: T.number,
   contributors: T.array,
+  defaultNotify: T.arrayOf(T.string),
   commentId: T.number,
   comment: T.string,
   initialSection: T.string,

--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -3,6 +3,7 @@ import T from 'prop-types';
 import styled from 'styled-components';
 import { Formik } from 'formik';
 import isHotkey from 'is-hotkey';
+import Select from 'react-select';
 import { glsp, themeVal, truncated } from '@devseed-ui/theme-provider';
 import { Button } from '@devseed-ui/button';
 import { Form } from '@devseed-ui/form';
@@ -72,6 +73,11 @@ const sectionMenuLabel = (selectedItems) => {
   return `Comment under ${selectedItems[0]?.label}`;
 };
 
+const contributorToSelectOption = ({ preferred_username, sub }) => ({
+  label: preferred_username,
+  value: sub
+});
+
 const getTextareaLabel = ({ type, values, setFieldValue }) => {
   switch (type) {
     case 'new':
@@ -102,18 +108,21 @@ const getInitialValues = ({ type, section, comment, threadId, commentId }) => {
       return {
         section:
           !section || section === THREAD_SECTION_ALL ? 'general' : section,
-        comment: ''
+        comment: '',
+        notify: []
       };
     case 'reply':
       return {
         threadId,
-        comment: ''
+        comment: '',
+        notify: []
       };
     case 'edit':
       return {
         threadId,
         commentId,
-        comment
+        comment,
+        notify: []
       };
 
     default:
@@ -127,10 +136,13 @@ const CommentForm = (props) => {
     comment,
     initialSection,
     threadId,
+    contributors,
     commentId,
     onSubmit,
     onCancel
   } = props;
+
+  const contributorsSelectOptions = contributors.map(contributorToSelectOption);
 
   const formRef = useRef(null);
 
@@ -169,6 +181,16 @@ const CommentForm = (props) => {
             handleSubmit();
           }
         };
+
+        const notifyValue = contributorsSelectOptions.filter(({ value }) =>
+          values.notify.includes(value)
+        );
+
+        const handleNotifyChange = (values) => {
+          const notifyIds = values.map(({ value }) => value);
+          setFieldValue('notify', notifyIds);
+        };
+
         return (
           <Form onSubmit={handleSubmit} ref={formRef}>
             <FormikInputTextarea
@@ -177,6 +199,14 @@ const CommentForm = (props) => {
               label={getTextareaLabel({ type, values, setFieldValue })}
               onKeyDown={onKeyDown}
             />
+            {contributors.length > 0 && (
+              <Select
+                isMulti
+                options={contributorsSelectOptions}
+                value={notifyValue}
+                onChange={handleNotifyChange}
+              />
+            )}
             <FormActions>
               <Tip title={modKey('mod+↵')}>
                 <Button
@@ -211,11 +241,16 @@ const CommentForm = (props) => {
 CommentForm.propTypes = {
   type: T.oneOf(['new', 'reply', 'edit']),
   threadId: T.number,
+  contributors: T.array,
   commentId: T.number,
   comment: T.string,
   initialSection: T.string,
   onSubmit: T.func,
   onCancel: T.func
+};
+
+CommentForm.defaultProps = {
+  contributors: []
 };
 
 export default CommentForm;

--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -10,6 +10,7 @@ import { Form } from '@devseed-ui/form';
 
 import DropdownMenu from '../common/dropdown-menu';
 import { FormikInputTextarea } from '../common/forms/input-textarea';
+import FormGroupStructure from '../common/forms/form-group-structure';
 import Tip from '../common/tooltip';
 
 import { DOCUMENT_SECTIONS } from '../documents/single-edit/sections';
@@ -204,12 +205,19 @@ const CommentForm = (props) => {
               onKeyDown={onKeyDown}
             />
             {contributors.length > 0 && (
-              <Select
-                isMulti
-                options={contributorsSelectOptions}
-                value={notifyValue}
-                onChange={handleNotifyChange}
-              />
+              <FormGroupStructure
+                id='notify'
+                label='Notify users'
+                helper='If left blank, all contributors to this ATBD will be notified.'
+              >
+                <Select
+                  isMulti
+                  inputId='notify'
+                  options={contributorsSelectOptions}
+                  value={notifyValue}
+                  onChange={handleNotifyChange}
+                />
+              </FormGroupStructure>
             )}
             <FormActions>
               <Tip title={modKey('mod+↵')}>

--- a/app/assets/scripts/components/comment-center/comment-form.js
+++ b/app/assets/scripts/components/comment-center/comment-form.js
@@ -15,6 +15,7 @@ import Tip from '../common/tooltip';
 import { DOCUMENT_SECTIONS } from '../documents/single-edit/sections';
 import { modKey } from '../slate/plugins/common/utils';
 import { THREAD_SECTION_ALL } from './common';
+import { useUser } from '../../context/user';
 
 const SectionsDropdownMenu = styled(DropdownMenu)`
   max-width: 18rem;
@@ -142,8 +143,6 @@ const CommentForm = (props) => {
     onCancel
   } = props;
 
-  const contributorsSelectOptions = contributors.map(contributorToSelectOption);
-
   const formRef = useRef(null);
 
   const onSubmitWithBlur = useCallback(
@@ -165,6 +164,11 @@ const CommentForm = (props) => {
       }),
     [type, comment, threadId, commentId, initialSection]
   );
+
+  const { user } = useUser();
+  const contributorsSelectOptions = contributors
+    .filter(({ sub }) => sub !== user.id) // Removes active user from select options
+    .map(contributorToSelectOption);
 
   return (
     <Formik

--- a/app/assets/scripts/components/comment-center/thread-list-panel.js
+++ b/app/assets/scripts/components/comment-center/thread-list-panel.js
@@ -48,6 +48,7 @@ function ThreadListPanelContents() {
   const {
     atbdId,
     atbdVersion,
+    contributors,
     setPanelOpen,
     selectedSection,
     setSelectedSection,
@@ -286,6 +287,7 @@ function ThreadListPanelContents() {
         <CommentFormWrapper>
           <CommentForm
             threadId={openThreadId}
+            contributors={contributors}
             initialSection={selectedSection}
             type='new'
             onSubmit={onSubmitThread}

--- a/app/assets/scripts/components/comment-center/thread-single-panel.js
+++ b/app/assets/scripts/components/comment-center/thread-single-panel.js
@@ -46,7 +46,8 @@ function ThreadSinglePanelContents() {
     openThreadId: threadId,
     setOpenThreadId,
     setEditingCommentKey,
-    editingCommentKey
+    editingCommentKey,
+    contributors
   } = useCommentCenter();
 
   const {
@@ -249,6 +250,7 @@ function ThreadSinglePanelContents() {
         <CommentFormWrapper>
           <CommentForm
             threadId={threadId}
+            contributors={contributors}
             type='reply'
             onSubmit={onSubmitThreadComment}
           />

--- a/app/assets/scripts/components/comment-center/thread-single-panel.js
+++ b/app/assets/scripts/components/comment-center/thread-single-panel.js
@@ -251,6 +251,7 @@ function ThreadSinglePanelContents() {
           <CommentForm
             threadId={threadId}
             contributors={contributors}
+            defaultNotify={threadCtx.data?.notify}
             type='reply'
             onSubmit={onSubmitThreadComment}
           />

--- a/app/assets/scripts/context/comment-center.js
+++ b/app/assets/scripts/context/comment-center.js
@@ -32,6 +32,7 @@ export const CommentCenterProvider = ({ children }) => {
   const [selectedStatus, setSelectedStatus] = useState(THREAD_STATUS_ALL);
   const [atbdId, setAtbdId] = useState(null);
   const [atbdVersion, setAtbdVersion] = useState(null);
+  const [contributors, setContributors] = useState(null);
   // The key of the editing comment will be `threadId-commentId`
   const [editingCommentKey, setEditingCommentKey] = useState(null);
 
@@ -79,6 +80,8 @@ export const CommentCenterProvider = ({ children }) => {
     setAtbdId,
     atbdVersion,
     setAtbdVersion,
+    contributors,
+    setContributors,
     openPanelOn
   };
 
@@ -110,13 +113,19 @@ const useSafeContextFn = createContextChecker(
 export const useCommentCenter = ({ atbd = null } = {}) => {
   const ctx = useSafeContextFn('useCommentCenter');
 
-  const { id, version } = atbd?.data || {};
+  const { id, version, owner, authors = [], reviewers = [] } = atbd?.data || {};
+  const contributors = useMemo(() => [owner, ...authors, ...reviewers], [
+    owner,
+    authors,
+    reviewers
+  ]);
 
   useEffectPrevious(
     (prev) => {
       if (!id || !version) return;
       ctx.setAtbdId(id);
       ctx.setAtbdVersion(version);
+      ctx.setContributors(contributors);
 
       // If the panel is open and the atbd changes update the values.
       // This happens when switching versions.
@@ -129,7 +138,7 @@ export const useCommentCenter = ({ atbd = null } = {}) => {
         });
       }
     },
-    [id, version, ctx.isPanelOpen, ctx.openPanelOn]
+    [id, version, contributors, ctx.isPanelOpen, ctx.openPanelOn]
   );
 
   return ctx;

--- a/app/assets/scripts/context/threads-list.js
+++ b/app/assets/scripts/context/threads-list.js
@@ -194,7 +194,7 @@ export const ThreadsProvider = ({ children }) => {
       mutations: {
         createThread: withRequestToken(
           token,
-          ({ atbdId, atbdVersion, section, comment }) => ({
+          ({ atbdId, atbdVersion, section, comment, notify }) => ({
             skipStateCheck: true,
             sliceKey: `${atbdId}-${atbdVersion}`,
             url: `/threads`,
@@ -202,7 +202,8 @@ export const ThreadsProvider = ({ children }) => {
               method: 'POST',
               data: {
                 comment: {
-                  body: comment
+                  body: comment,
+                  notify
                 },
                 atbd_id: atbdId,
                 version: atbdVersion,
@@ -322,14 +323,15 @@ export const ThreadsProvider = ({ children }) => {
         ),
         createThreadsComment: withRequestToken(
           token,
-          ({ threadId, comment }) => ({
+          ({ threadId, comment, notify }) => ({
             skipStateCheck: true,
             sliceKey: `${threadId}`,
             url: `/threads/${threadId}/comments`,
             requestOptions: {
               method: 'POST',
               data: {
-                body: comment
+                body: comment,
+                notify
               }
             },
             transformData: (data, { state }) => {
@@ -520,8 +522,8 @@ export const useThreads = ({ atbdId, atbdVersion }) => {
       [atbdId, atbdVersion, fetchThreadsList]
     ),
     createThread: useCallback(
-      ({ comment, section }) =>
-        createThread({ atbdId, atbdVersion, comment, section }),
+      ({ comment, section, notify }) =>
+        createThread({ atbdId, atbdVersion, comment, section, notify }),
       [atbdId, atbdVersion, createThread]
     )
   };
@@ -565,7 +567,8 @@ export const useSingleThread = ({ threadId } = {}) => {
       [threadId, deleteThreadsSingle]
     ),
     createThreadComment: useCallback(
-      ({ comment }) => createThreadsComment({ comment, threadId }),
+      ({ comment, notify }) =>
+        createThreadsComment({ comment, notify, threadId }),
       [threadId, createThreadsComment]
     ),
     deleteThreadComment: useCallback(

--- a/app/assets/scripts/context/threads-list.js
+++ b/app/assets/scripts/context/threads-list.js
@@ -202,9 +202,9 @@ export const ThreadsProvider = ({ children }) => {
               method: 'POST',
               data: {
                 comment: {
-                  body: comment,
-                  notify
+                  body: comment
                 },
+                notify,
                 atbd_id: atbdId,
                 version: atbdVersion,
                 section


### PR DESCRIPTION
Contributes front-end implementation for https://github.com/NASA-IMPACT/nasa-apt/issues/456

- Adds a new field to the comment that allows to select people for notification about the comment. 
- The list of people included for selection includes all contributers (owner, reviewers, authors) of the document.
- People selected for notification are persisted and pre-populated for responses to the comment.

Test this together with https://github.com/NASA-IMPACT/nasa-apt/pull/544