### PR TITLE
Remove in-publication status

### DIFF
--- a/app/assets/scripts/components/dashboard/document-list-settings.js
+++ b/app/assets/scripts/components/dashboard/document-list-settings.js
@@ -13,11 +13,9 @@ import {
   getDocumentStatusLabel,
   isDraftEquivalent,
   isReviewEquivalent,
-  isPublication,
   isPublished,
   DRAFT,
   OPEN_REVIEW,
-  PUBLICATION,
   PUBLISHED
 } from '../documents/status';
 import { computeAtbdVersion } from '../../context/atbds-list';
@@ -66,10 +64,6 @@ const statusOptions = [
   {
     id: OPEN_REVIEW,
     filterFn: isReviewEquivalent
-  },
-  {
-    id: PUBLICATION,
-    filterFn: isPublication
   },
   {
     id: PUBLISHED,

--- a/app/assets/scripts/components/dashboard/index.js
+++ b/app/assets/scripts/components/dashboard/index.js
@@ -29,11 +29,9 @@ import {
   DRAFT,
   getDocumentStatusLabel,
   isDraftEquivalent,
-  isPublication,
   isPublished,
   isReviewEquivalent,
   OPEN_REVIEW,
-  PUBLICATION,
   PUBLISHED
 } from '../documents/status';
 import { round } from '../../utils/format';
@@ -262,7 +260,6 @@ function CuratorInsights() {
           total: docAcc.total + 1,
           DRAFT: docAcc.DRAFT + Number(isDraftEquivalent(ver)),
           OPEN_REVIEW: docAcc.OPEN_REVIEW + Number(isReviewEquivalent(ver)),
-          PUBLICATION: docAcc.PUBLICATION + Number(isPublication(ver)),
           PUBLISHED: docAcc.PUBLISHED + Number(isPublished(ver))
         };
       }, acc);
@@ -275,7 +272,7 @@ function CuratorInsights() {
     <InsightsBlock>
       <InsightsBlockTitle>Insights</InsightsBlockTitle>
       <InsightsBlockContent>
-        {[DRAFT, OPEN_REVIEW, PUBLICATION, PUBLISHED].map((status) => (
+        {[DRAFT, OPEN_REVIEW, PUBLISHED].map((status) => (
           <Insight
             key={status}
             id={status.toLowerCase()}

--- a/app/assets/scripts/components/documents/document-tracker-modal.js
+++ b/app/assets/scripts/components/documents/document-tracker-modal.js
@@ -30,12 +30,10 @@ import {
   isDraft,
   isDraftEquivalent,
   isOpenReview,
-  isPublication,
   isPublicationRequested,
   isPublished,
   isStatusAfter,
   OPEN_REVIEW,
-  PUBLICATION,
   PUBLICATION_REQUESTED,
   PUBLISHED,
   REVIEW_DONE
@@ -211,8 +209,6 @@ export default function DocumentTrackerModal(props) {
       isClosedReview(atbd),
       // Fold index 2:
       isOpenReview(atbd) || isPublicationRequested(atbd),
-      // Fold index 3:
-      isPublication(atbd),
       // Fold index 4:
       isPublished(atbd)
     ],
@@ -331,28 +327,6 @@ export default function DocumentTrackerModal(props) {
                       </TrackerEntry>
                     </TrackerItem>
                   </SubTracker>
-                </TrackerItem>
-                <TrackerItem status={checkStatusProgress(PUBLICATION)}>
-                  <TrackerEntryFold
-                    index={3}
-                    checkExpanded={checkExpanded}
-                    setExpanded={setExpanded}
-                    swatchColor={statusMapping[PUBLICATION]}
-                    title={getDocumentStatusLabel(PUBLICATION)}
-                    titleIcon={
-                      isPublication(atbd)
-                        ? journalStatusIcons[atbd.journal_status]
-                        : undefined
-                    }
-                    content={
-                      <p>
-                        If the document was scheduled to be published in the
-                        Journal, it goes through the journal publication process
-                        outside of APT, otherwise the the last actions are taken
-                        to have the document published on the platform.
-                      </p>
-                    }
-                  />
                 </TrackerItem>
                 <TrackerItem status={checkStatusProgress(PUBLISHED)}>
                   <TrackerEntryFold

--- a/app/assets/scripts/components/documents/status.js
+++ b/app/assets/scripts/components/documents/status.js
@@ -18,7 +18,6 @@ export const CLOSED_REVIEW_REQUESTED = 'CLOSED_REVIEW_REQUESTED';
 export const CLOSED_REVIEW = 'CLOSED_REVIEW';
 export const OPEN_REVIEW = 'OPEN_REVIEW';
 export const PUBLICATION_REQUESTED = 'PUBLICATION_REQUESTED';
-export const PUBLICATION = 'PUBLICATION';
 export const PUBLISHED = 'PUBLISHED';
 
 export const DOCUMENT_STATUS = [
@@ -27,8 +26,7 @@ export const DOCUMENT_STATUS = [
   { id: CLOSED_REVIEW, label: 'In closed review' },
   { id: OPEN_REVIEW, label: 'In review' },
   { id: PUBLICATION_REQUESTED, label: 'In review' },
-  { id: PUBLICATION, label: 'In publication' },
-  { id: PUBLISHED, label: 'Published' }
+  { id: PUBLISHED, label: 'Public' }
 ];
 
 /**
@@ -141,21 +139,12 @@ export const isPublicationRequested = (versionOrStatus) => {
 };
 
 /**
- * Checks that the given document or status string is in Publication
- * @param {object|string} versionOrStatus The doc version or the status string
- * @returns boolean
- */
-export const isPublication = (versionOrStatus) => {
-  return isInStatus(versionOrStatus, [PUBLICATION]);
-};
-
-/**
  * Checks that the given document or status string is in Publication or after
  * @param {object|string} versionOrStatus The doc version or the status string
  * @returns boolean
  */
 export const isPublicationOrAfter = (versionOrStatus) => {
-  return isInStatus(versionOrStatus, [PUBLICATION, PUBLISHED]);
+  return isInStatus(versionOrStatus, [PUBLISHED]);
 };
 
 /**


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/480

- Removes the "In Publication status" and all adjacent functionality from the code base
- Renames status "Published" to "Public"