### PR TITLE
Remove in-publication step

### DIFF
--- a/app/assets/scripts/a11n/rules.js
+++ b/app/assets/scripts/a11n/rules.js
@@ -5,7 +5,6 @@ import {
   CLOSED_REVIEW_REQUESTED,
   DRAFT,
   OPEN_REVIEW,
-  PUBLICATION,
   PUBLICATION_REQUESTED,
   REVIEW_PROGRESS
 } from '../components/documents/status';
@@ -46,11 +45,8 @@ export function defineRulesFor(user) {
       allow('open-review', 'document-version', {
         status: CLOSED_REVIEW
       });
-      allow('manage-req-publication', 'document-version', {
-        status: PUBLICATION_REQUESTED
-      });
       allow('publish', 'document-version', {
-        status: PUBLICATION
+        status: PUBLICATION_REQUESTED
       });
       allow('access-comments', 'document-version');
       allow('download-journal-pdf', 'document-version');

--- a/app/assets/scripts/components/dashboard/document-list-settings.js
+++ b/app/assets/scripts/components/dashboard/document-list-settings.js
@@ -381,7 +381,6 @@ function getDocAbilitySortRating(doc, ability) {
     ability.can('open-review', doc) ||
     ability.can('req-publication', doc) ||
     ability.can('cancel-req-publication', doc) ||
-    ability.can('manage-req-publication', doc) ||
     ability.can('publish', doc)
     ? -1
     : 1;

--- a/app/assets/scripts/components/dashboard/use-document-menu-action.js
+++ b/app/assets/scripts/components/dashboard/use-document-menu-action.js
@@ -102,8 +102,6 @@ export function useDocumentHubMenuAction() {
         case 'change-leading':
         case 'req-review-allow':
         case 'req-review-deny':
-        case 'req-publication-allow':
-        case 'req-publication-deny':
         case 'toggle-comments':
           // To trigger the modals to open from other pages, we use the history
           // state as the user is sent from one page to another. See explanation

--- a/app/assets/scripts/components/documents/document-governance-action.js
+++ b/app/assets/scripts/components/documents/document-governance-action.js
@@ -100,7 +100,7 @@ export default function DocumentGovernanceAction(props) {
       <Can do='req-publication' on={atbd}>
         <control.El
           {...control.props}
-          title='Submit document for publication'
+          title='Make-public request'
           useIcon='arrow-up-right'
           disabled={isMutating}
           onClick={() => onAction('req-publication', { atbd })}
@@ -111,7 +111,7 @@ export default function DocumentGovernanceAction(props) {
       <Can do='cancel-req-publication' on={atbd}>
         <control.El
           {...control.props}
-          title='Cancel publication request'
+          title='Cancel make-public request'
           useIcon='xmark--small'
           disabled={isMutating}
           onClick={() => onAction('cancel-req-publication', { atbd })}
@@ -119,19 +119,10 @@ export default function DocumentGovernanceAction(props) {
           Cancel request
         </control.El>
       </Can>
-      <Can do='manage-req-publication' on={atbd}>
-        <AllowDeny
-          id='req-publication'
-          triggerLabel='Approve request'
-          triggerProps={control.triggerProps}
-          dropTitle='Request for publication'
-          onSelect={onAction}
-        />
-      </Can>
       <Can do='publish' on={atbd}>
         <control.El
           {...control.props}
-          title='Publish document'
+          title='Make public'
           useIcon='arrow-up'
           disabled={isMutating}
           onClick={() => onAction('publish', { atbd })}

--- a/app/assets/scripts/context/atbds-list.js
+++ b/app/assets/scripts/context/atbds-list.js
@@ -628,14 +628,6 @@ export const useSingleAtbdEvents = ({ id, version }) => {
       () => createFireEvent('cancel_publication_request'),
       [createFireEvent]
     ),
-    fevApprovePublicationReq: useMemo(
-      () => createFireEvent('accept_publication_request'),
-      [createFireEvent]
-    ),
-    fevDenyPublicationReq: useMemo(
-      () => createFireEvent('deny_publication_request'),
-      [createFireEvent]
-    ),
     fevPublish: useMemo(() => createFireEvent('publish'), [createFireEvent]),
     fevMinorVersion: useMemo(() => createFireEvent('bump_minor_version'), [
       createFireEvent


### PR DESCRIPTION
Front-end changes for https://github.com/NASA-IMPACT/nasa-apt/issues/480

- Removes the in-publication document status, and UI components
- Adapts permissions so ATBD can be made public after requesting publications

Test together with https://github.com/NASA-IMPACT/nasa-apt/pull/553