### PR TITLE
Read version description of current version from ATBD

### DIFF
--- a/app/assets/scripts/components/documents/document-changelog-modal.js
+++ b/app/assets/scripts/components/documents/document-changelog-modal.js
@@ -36,11 +36,15 @@ export default function DocumentChangelogModal(props) {
   const content = atbd.versions.map(({ version, document }) => {
     const pdfUrl = `${apiUrl}/atbds/${atbd.id}/versions/${version}/pdf`;
 
+    const version_description = document
+      ? document.version_description
+      : atbd.document.version_description;
+
     return (
       <Version key={version}>
         <h3>{version}</h3>
         <SafeReadEditor
-          value={document.version_description}
+          value={version_description}
           whenEmpty='No summary available'
         />
         <Downloads>


### PR DESCRIPTION
Fixes a bug with the changeling modal.

**Problem**

The current version in the `versions` array doesn't include the `document` after updating the ATBD. That's why we're seeing a fatal error because the version changeling tries to read the `document` value and can't find it. 

**How to test**

- Edit an ATBD
- Save
- Saving should not cause an error
