### PR TITLE
Add publish-workflow tests

### DIFF
--- a/app/assets/scripts/components/common/toasts.js
+++ b/app/assets/scripts/components/common/toasts.js
@@ -66,7 +66,8 @@ export const createProcessToast = (msg) => {
 
 export const ToastsContainer = styled(ToastContainer).attrs({
   position: toast.POSITION.BOTTOM_RIGHT,
-  closeButton: CloseButton
+  closeButton: CloseButton,
+  containerId: 'the-toast'
 })`
   padding: 0;
 

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -24,16 +24,21 @@ describe('Publish workflow', () => {
   it('owner requests review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('owner');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
     cy.contains(/Request review/).click();
@@ -48,44 +53,61 @@ describe('Publish workflow', () => {
   });
 
   it('owner cannot request review if not draft', () => {
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1/versions/v1.1', atbdVersions);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept('GET', '/v2/atbds/test-atbd-1/versions/v1.1', atbdVersions).as(
+      'versionRequest'
+    );
 
     cy.login('owner');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Request review/).should('not.exist');
   });
 
   it('curator cannot request review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('curator');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Request review/).should('not.exist');
   });
 
   it('contributor cannot request review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('contributor');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Request review/).should('not.exist');
   });
 
@@ -95,16 +117,21 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('owner');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
     cy.contains(/Cancel request/).click();
@@ -121,16 +148,21 @@ describe('Publish workflow', () => {
   it('owner cannot cancel review request if not review is not requested', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('owner');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Cancel request/).should('not.exist');
   });
 
@@ -140,16 +172,21 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('curator');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Cancel request/).should('not.exist');
   });
 
@@ -159,16 +196,21 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
 
     cy.login('contributor');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Cancel request/).should('not.exist');
   });
 
@@ -178,13 +220,15 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
     cy.intercept(
       'GET',
       '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
@@ -195,6 +239,9 @@ describe('Publish workflow', () => {
 
     cy.login('curator');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Approve request/).click();
     cy.contains(/Allow.../).click();
     cy.contains(/Approve review request/).should('exist');
@@ -221,13 +268,15 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
     cy.intercept(
       'GET',
       '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
@@ -238,6 +287,9 @@ describe('Publish workflow', () => {
 
     cy.login('curator');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Approve request/).click();
     cy.contains(/Deny.../).click();
     cy.contains(/Deny review request/).should('exist');
@@ -264,13 +316,15 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
     cy.intercept(
       'GET',
       '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
@@ -281,6 +335,9 @@ describe('Publish workflow', () => {
 
     cy.login('owner');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Approve request/).should('not.exist');
   });
 
@@ -290,13 +347,15 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
     cy.intercept(
       'GET',
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
-    );
+    ).as('versionRequest');
     cy.intercept(
       'GET',
       '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
@@ -307,6 +366,9 @@ describe('Publish workflow', () => {
 
     cy.login('contributor');
     cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
     cy.contains(/Approve request/).should('not.exist');
   });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -21,13 +21,10 @@ function versionWithStatus(version, status) {
 }
 
 describe('Publish workflow', () => {
-  beforeEach(() => {
-    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
-  });
-
   it('owner requests review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -51,6 +48,7 @@ describe('Publish workflow', () => {
   });
 
   it('owner cannot request review if not draft', () => {
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept('GET', '/v2/atbds/test-atbd-1/versions/v1.1', atbdVersions);
 
@@ -62,6 +60,7 @@ describe('Publish workflow', () => {
   it('curator cannot request review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -77,6 +76,7 @@ describe('Publish workflow', () => {
   it('contributor cannot request review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -95,6 +95,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -120,6 +121,7 @@ describe('Publish workflow', () => {
   it('owner cannot cancel review request if not review is not requested', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -138,6 +140,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -156,6 +159,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -174,6 +178,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -216,6 +221,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -258,6 +264,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',
@@ -283,6 +290,7 @@ describe('Publish workflow', () => {
       'CLOSED_REVIEW_REQUESTED'
     );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
     cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
     cy.intercept(
       'GET',

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -1,0 +1,92 @@
+const atbds = require('../../fixtures/server/atbds.json');
+const stats = require('../../fixtures/server/stats.json');
+const atbd = require('../../fixtures/server/atbd.json');
+const atbdVersions = require('../../fixtures/server/atbd-versions.json');
+const atbdEvent = require('../../fixtures/server/atbd-event.json');
+
+function versionWithStatus(version, status) {
+  return {
+    ...version,
+    versions: version.versions.map((v) => {
+      if (v.major === 1 && v.minor === 1) {
+        return {
+          ...v,
+          status
+        };
+      } else {
+        return v;
+      }
+    })
+  };
+}
+
+describe('Publish workflow', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v2/atbds?role=owner', atbds);
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
+  });
+
+  it('owner requests review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.contains(/Request review/).click();
+    cy.get('#the-toast').contains('Review requested successfully');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'request_closed_review',
+      payload: {}
+    });
+  });
+
+  it('owner cannot request review if not draft', () => {
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept('GET', '/v2/atbds/test-atbd-1/versions/v1.1', atbdVersions);
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Request review/).should('not.exist');
+  });
+
+  it('curator cannot request review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Request review/).should('not.exist');
+  });
+
+  it('contributor cannot request review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Request review/).should('not.exist');
+  });
+});

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -3,6 +3,7 @@ const stats = require('../../fixtures/server/stats.json');
 const atbd = require('../../fixtures/server/atbd.json');
 const atbdVersions = require('../../fixtures/server/atbd-versions.json');
 const atbdEvent = require('../../fixtures/server/atbd-event.json');
+const atbdReviewerList = require('../../fixtures/server/atbd-reviewer-list.json');
 
 function versionWithStatus(version, status) {
   return {
@@ -167,5 +168,139 @@ describe('Publish workflow', () => {
     cy.login('contributor');
     cy.visit('/documents/test-atbd-1/v1.1');
     cy.contains(/Cancel request/).should('not.exist');
+  });
+
+  it('curator approves review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Approve request/).click();
+    cy.contains(/Allow.../).click();
+    cy.contains(/Approve review request/).should('exist');
+
+    cy.contains('Ricardo Reviewer').click();
+    cy.get('[title="Approve review request of document"]').click();
+    cy.get('#the-toast').contains('Review request approved successfully');
+
+    cy.get('@reviewRequest')
+      .its('request.body')
+      .should('deep.equal', {
+        atbd_id: 'test-atbd-1',
+        version: 'v1.1',
+        action: 'accept_closed_review_request',
+        payload: {
+          reviewers: ['6844a7fe-2bbd-4648-a9b4-5b1a6884038e']
+        }
+      });
+  });
+
+  it('curator cancels review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Approve request/).click();
+    cy.contains(/Deny.../).click();
+    cy.contains(/Deny review request/).should('exist');
+
+    cy.get('#comment').type('Not ready');
+    cy.get('[title="Deny request"]').click();
+    cy.get('#the-toast').contains('Review request denied successfully');
+
+    cy.get('@reviewRequest')
+      .its('request.body')
+      .should('deep.equal', {
+        atbd_id: 'test-atbd-1',
+        version: 'v1.1',
+        action: 'deny_closed_review_request',
+        payload: {
+          comment: 'Not ready'
+        }
+      });
+  });
+
+  it('owner cannot approve review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Approve request/).should('not.exist');
+  });
+
+  it('contributor cannot approve review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Approve request/).should('not.exist');
   });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -371,4 +371,98 @@ describe('Publish workflow', () => {
     cy.wait('@versionRequest');
     cy.contains(/Approve request/).should('not.exist');
   });
+
+  it.only('curator concludes review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Conclude closed review/).click();
+    cy.contains(/Confirm/).click();
+
+    cy.get('#the-toast').contains('Review opened successfully');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'open_review',
+      payload: {}
+    });
+  });
+
+  it.only('owner cannot conclude review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Conclude closed review/).should('not.exist');
+  });
+
+  it.only('contributor cannot conclude review', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+    cy.intercept(
+      'GET',
+      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
+      atbdReviewerList
+    );
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Conclude closed review/).should('not.exist');
+  });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -472,7 +472,41 @@ describe('Publish workflow', () => {
     });
   });
 
-  it.only('curator can not request publication', () => {
+  it('owner can cancel publication request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'PUBLICATION_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Cancel request/).click();
+
+    cy.get('#the-toast').contains('Publication request cancelled successfully');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'cancel_publication_request',
+      payload: {}
+    });
+  });
+
+  it('curator can not request publication', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'OPEN_REVIEW');
 
     cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
@@ -516,27 +550,120 @@ describe('Publish workflow', () => {
     cy.contains(/Request publication/).should('not.exist');
   });
 
-  it('curator can approve publication', () => {
-    
-  });
-  
-  it('contributor can not request publication', () => {
-    
-  });
-
-  it('owner can not approve publication', () => {
-
-  });
-
   it('curator can publish document', () => {
-    
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'PUBLICATION_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+
+    cy.contains(/Publish/).click();
+    cy.contains(/Publish document/).should('exist');
+    cy.get('[title="Publish document"]').click();
+
+    cy.get('#the-toast').contains('Version v1.1 was published');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'publish',
+      payload: {}
+    });
   });
-  
+
+  it('curator can deny publication', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'PUBLICATION_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+
+    cy.contains(/Publish/).click();
+    cy.contains(/Publish document/).should('exist');
+    cy.get('[title="Cancel publication"]').click();
+  });
+
   it('contributor can not publish document', () => {
-    
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'PUBLICATION_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+
+    cy.contains(/Publish/).should('not.exist');
   });
 
   it('owner can not publish document', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'PUBLICATION_REQUESTED'
+    );
 
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+
+    cy.contains(/Publish/).should('not.exist');
   });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -89,4 +89,83 @@ describe('Publish workflow', () => {
     cy.visit('/documents/test-atbd-1/v1.1');
     cy.contains(/Request review/).should('not.exist');
   });
+
+  it('owner cancels review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.contains(/Cancel request/).click();
+    cy.get('#the-toast').contains('Review request cancelled successfully');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'cancel_closed_review_request',
+      payload: {}
+    });
+  });
+
+  it('owner cannot cancel review request if not review is not requested', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'DRAFT');
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Cancel request/).should('not.exist');
+  });
+
+  it('curator cannot cancel review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Cancel request/).should('not.exist');
+  });
+
+  it('contributor cannot cancel review request', () => {
+    const draftAtbdVersions = versionWithStatus(
+      atbdVersions,
+      'CLOSED_REVIEW_REQUESTED'
+    );
+
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd);
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    );
+
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.contains(/Cancel request/).should('not.exist');
+  });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -325,11 +325,6 @@ describe('Publish workflow', () => {
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
     ).as('versionRequest');
-    cy.intercept(
-      'GET',
-      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
-      atbdReviewerList
-    );
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
 
@@ -356,11 +351,6 @@ describe('Publish workflow', () => {
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
     ).as('versionRequest');
-    cy.intercept(
-      'GET',
-      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
-      atbdReviewerList
-    );
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
 
@@ -372,7 +362,7 @@ describe('Publish workflow', () => {
     cy.contains(/Approve request/).should('not.exist');
   });
 
-  it.only('curator concludes review', () => {
+  it('curator concludes review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
 
     cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
@@ -384,11 +374,6 @@ describe('Publish workflow', () => {
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
     ).as('versionRequest');
-    cy.intercept(
-      'GET',
-      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
-      atbdReviewerList
-    );
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
 
@@ -410,7 +395,7 @@ describe('Publish workflow', () => {
     });
   });
 
-  it.only('owner cannot conclude review', () => {
+  it('owner cannot conclude review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
 
     cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
@@ -422,11 +407,6 @@ describe('Publish workflow', () => {
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
     ).as('versionRequest');
-    cy.intercept(
-      'GET',
-      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
-      atbdReviewerList
-    );
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
 
@@ -438,7 +418,7 @@ describe('Publish workflow', () => {
     cy.contains(/Conclude closed review/).should('not.exist');
   });
 
-  it.only('contributor cannot conclude review', () => {
+  it('contributor cannot conclude review', () => {
     const draftAtbdVersions = versionWithStatus(atbdVersions, 'CLOSED_REVIEW');
 
     cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
@@ -450,11 +430,6 @@ describe('Publish workflow', () => {
       '/v2/atbds/test-atbd-1/versions/v1.1',
       draftAtbdVersions
     ).as('versionRequest');
-    cy.intercept(
-      'GET',
-      '/v2/users?atbd_id=1&version=v1.1&user_filter=invite_reviewers',
-      atbdReviewerList
-    );
 
     cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
 
@@ -464,5 +439,104 @@ describe('Publish workflow', () => {
     cy.wait('@atbdRequest');
     cy.wait('@versionRequest');
     cy.contains(/Conclude closed review/).should('not.exist');
+  });
+
+  it('owner can request publication', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'OPEN_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('owner');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Request publication/).click();
+
+    cy.get('#the-toast').contains('Publication requested successfully');
+
+    cy.get('@reviewRequest').its('request.body').should('deep.equal', {
+      atbd_id: 'test-atbd-1',
+      version: 'v1.1',
+      action: 'request_publication',
+      payload: {}
+    });
+  });
+
+  it.only('curator can not request publication', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'OPEN_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('curator');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Request publication/).should('not.exist');
+  });
+
+  it('contributor can not request publication', () => {
+    const draftAtbdVersions = versionWithStatus(atbdVersions, 'OPEN_REVIEW');
+
+    cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats).as(
+      'statsRequest'
+    );
+    cy.intercept('GET', '/v2/atbds/test-atbd-1', atbd).as('atbdRequest');
+    cy.intercept(
+      'GET',
+      '/v2/atbds/test-atbd-1/versions/v1.1',
+      draftAtbdVersions
+    ).as('versionRequest');
+
+    cy.intercept('POST', '/v2/events', atbdEvent).as('reviewRequest');
+    cy.login('contributor');
+    cy.visit('/documents/test-atbd-1/v1.1');
+    cy.wait('@statsRequest');
+    cy.wait('@atbdRequest');
+    cy.wait('@versionRequest');
+    cy.contains(/Request publication/).should('not.exist');
+  });
+
+  it('curator can approve publication', () => {
+    
+  });
+  
+  it('contributor can not request publication', () => {
+    
+  });
+
+  it('owner can not approve publication', () => {
+
+  });
+
+  it('curator can publish document', () => {
+    
+  });
+  
+  it('contributor can not publish document', () => {
+    
+  });
+
+  it('owner can not publish document', () => {
+
   });
 });

--- a/cypress/e2e/document/publish-workflow.js
+++ b/cypress/e2e/document/publish-workflow.js
@@ -1,4 +1,3 @@
-const atbds = require('../../fixtures/server/atbds.json');
 const stats = require('../../fixtures/server/stats.json');
 const atbd = require('../../fixtures/server/atbd.json');
 const atbdVersions = require('../../fixtures/server/atbd-versions.json');
@@ -23,7 +22,6 @@ function versionWithStatus(version, status) {
 
 describe('Publish workflow', () => {
   beforeEach(() => {
-    cy.intercept('GET', '/v2/atbds?role=owner', atbds);
     cy.intercept('GET', '/v2/threads/stats?atbds=1_v1.1', stats);
   });
 

--- a/cypress/fixtures/server/atbd-event.json
+++ b/cypress/fixtures/server/atbd-event.json
@@ -9,8 +9,8 @@
   "versions": [
     {
       "major": 1,
-      "minor": 0,
-      "version": "v1.0",
+      "minor": 1,
+      "version": "v1.1",
       "status": "CLOSED_REVIEW_REQUESTED",
       "published_by": null,
       "published_at": null,

--- a/cypress/fixtures/server/atbd-event.json
+++ b/cypress/fixtures/server/atbd-event.json
@@ -1,0 +1,72 @@
+{
+  "id": 2,
+  "created_by": "33b94622-80c5-4443-8bb2-2e124219afea",
+  "created_at": "2021-03-14T14:30:00+00:00",
+  "last_updated_by": "33b94622-80c5-4443-8bb2-2e124219afea",
+  "last_updated_at": "2021-03-15T16:00:00+00:00",
+  "title": "Project algorithms technically overly simplistic",
+  "alias": "patos",
+  "versions": [
+    {
+      "major": 1,
+      "minor": 0,
+      "version": "v1.0",
+      "status": "CLOSED_REVIEW_REQUESTED",
+      "published_by": null,
+      "published_at": null,
+      "sections_completed": {},
+      "created_by": {
+        "preferred_username": "Owner Olivia",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
+        "email": "owner@apt.com",
+        "cognito_groups": [
+          "contributor"
+        ]
+      },
+      "created_at": "2021-03-14T14:30:00+00:00",
+      "last_updated_by": {
+        "preferred_username": "Owner Olivia",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
+        "email": "owner@apt.com",
+        "cognito_groups": [
+          "contributor"
+        ]
+      },
+      "last_updated_at": "2022-09-09T02:12:55.423768+00:00",
+      "citation": {},
+      "document": {
+        "abstract": null,
+        "version_description": null
+      },
+      "keywords": [],
+      "owner": {
+        "preferred_username": "Owner Olivia",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
+        "email": "owner@apt.com",
+        "cognito_groups": [
+          "contributor"
+        ]
+      },
+      "authors": [
+        {
+          "preferred_username": "Andre Author",
+          "sub": "e09cf808-583c-4aab-b3a3-5a99ef9c9345",
+          "email": "author1@apt.com",
+          "cognito_groups": [
+            "contributor"
+          ]
+        },
+        {
+          "preferred_username": "Anita Author",
+          "sub": "576e5036-5e7f-4fda-97c8-f19077491046",
+          "email": "author2@apt.com",
+          "cognito_groups": [
+            "contributor"
+          ]
+        }
+      ],
+      "reviewers": [],
+      "journal_status": "NO_PUBLICATION"
+    }
+  ]
+}

--- a/cypress/fixtures/server/atbd-reviewer-list.json
+++ b/cypress/fixtures/server/atbd-reviewer-list.json
@@ -1,0 +1,34 @@
+[
+  {
+    "preferred_username": "Allison Author",
+    "sub": "c5da7223-7123-4d60-b48c-dd191a14ec0d",
+    "email": "author3@apt.com",
+    "cognito:groups": [
+      "contributor"
+    ]
+  },
+  {
+    "preferred_username": "Ricardo Reviewer",
+    "sub": "6844a7fe-2bbd-4648-a9b4-5b1a6884038e",
+    "email": "reviewer1@apt.com",
+    "cognito:groups": [
+      "contributor"
+    ]
+  },
+  {
+    "preferred_username": "Rita Reviewer",
+    "sub": "dedd64a4-96b5-4c36-82e7-d2f26df64cc4",
+    "email": "reviewer3@apt.com",
+    "cognito:groups": [
+      "contributor"
+    ]
+  },
+  {
+    "preferred_username": "Ronald Reviewer",
+    "sub": "1aad9bd2-ce5f-4d0d-9500-cfb3cf3c40b6",
+    "email": "reviewer2@apt.com",
+    "cognito:groups": [
+      "contributor"
+    ]
+  }
+]

--- a/cypress/fixtures/server/atbd-versions.json
+++ b/cypress/fixtures/server/atbd-versions.json
@@ -1,8 +1,8 @@
 {
   "id": 1,
-  "created_by": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+  "created_by": "33b94622-80c5-4443-8bb2-2e124219afea",
   "created_at": "2022-08-01T06:27:51.624274+00:00",
-  "last_updated_by": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+  "last_updated_by": "33b94622-80c5-4443-8bb2-2e124219afea",
   "last_updated_at": "2022-08-01T06:27:51.624274+00:00",
   "title": "Test ATBD 1",
   "alias": "test-atbd-1",
@@ -14,7 +14,7 @@
       "status": "PUBLISHED",
       "published_by": {
         "preferred_username": "Carlos Curator",
-        "sub": "dcb84824-b65e-481a-a7af-d657c9906d63",
+        "sub": "57a4c1c0-3802-4edc-a141-baeb5b18d50f",
         "email": "curator@apt.com",
         "cognito_groups": [
           "curator"
@@ -23,7 +23,7 @@
       "sections_completed": {},
       "created_by": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -32,7 +32,7 @@
       "created_at": "2022-08-01T06:27:51.626928+00:00",
       "last_updated_by": {
         "preferred_username": "Andre Author",
-        "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+        "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
         "email": "author1@apt.com",
         "cognito_groups": [
           "contributor"
@@ -990,7 +990,7 @@
       ],
       "owner": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -999,7 +999,7 @@
       "authors": [
         {
           "preferred_username": "Andre Author",
-          "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+          "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
           "email": "author1@apt.com",
           "cognito_groups": [
             "contributor"

--- a/cypress/fixtures/server/atbd.json
+++ b/cypress/fixtures/server/atbd.json
@@ -1,8 +1,8 @@
 {
   "id": 1,
-  "created_by": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+  "created_by": "33b94622-80c5-4443-8bb2-2e124219afea",
   "created_at": "2022-08-01T06:27:51.624274+00:00",
-  "last_updated_by": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+  "last_updated_by": "33b94622-80c5-4443-8bb2-2e124219afea",
   "last_updated_at": "2022-08-01T06:27:51.624274+00:00",
   "title": "Test ATBD 1",
   "alias": "test-atbd-1",
@@ -14,7 +14,7 @@
       "status": "PUBLISHED",
       "published_by": {
         "preferred_username": "Carlos Curator",
-        "sub": "dcb84824-b65e-481a-a7af-d657c9906d63",
+        "sub": "57a4c1c0-3802-4edc-a141-baeb5b18d50f",
         "email": "curator@apt.com",
         "cognito_groups": [
           "curator"
@@ -24,7 +24,7 @@
       "sections_completed": {},
       "created_by": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -33,7 +33,7 @@
       "created_at": "2022-08-01T06:27:51.626928+00:00",
       "last_updated_by": {
         "preferred_username": "Andre Author",
-        "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+        "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
         "email": "author1@apt.com",
         "cognito_groups": [
           "contributor"
@@ -121,7 +121,7 @@
       ],
       "owner": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -130,7 +130,7 @@
       "authors": [
         {
           "preferred_username": "Andre Author",
-          "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+          "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
           "email": "author1@apt.com",
           "cognito_groups": [
             "contributor"
@@ -167,7 +167,7 @@
       "sections_completed": {},
       "created_by": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -176,7 +176,7 @@
       "created_at": "2022-08-01T06:27:51.629709+00:00",
       "last_updated_by": {
         "preferred_username": "Andre Author",
-        "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+        "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
         "email": "author1@apt.com",
         "cognito_groups": [
           "contributor"
@@ -264,7 +264,7 @@
       ],
       "owner": {
         "preferred_username": "Owner Olivia",
-        "sub": "4df968e7-692d-4c75-bc18-b447f2b2b6fa",
+        "sub": "33b94622-80c5-4443-8bb2-2e124219afea",
         "email": "owner@apt.com",
         "cognito_groups": [
           "contributor"
@@ -273,7 +273,7 @@
       "authors": [
         {
           "preferred_username": "Andre Author",
-          "sub": "6f406492-27e5-465c-a1e7-a9e7dd2bd09c",
+          "sub": "1fd0998a-4168-4844-8475-de624f9be2cf",
           "email": "author1@apt.com",
           "cognito_groups": [
             "contributor"

--- a/cypress/support/login.js
+++ b/cypress/support/login.js
@@ -47,13 +47,32 @@ function signAccessToken(userId, username, access) {
   return sign(payload, 'sshhhh');
 }
 
-Cypress.Commands.add('login', (access = 'contributor') => {
-  const userId = '8c05f074-5c79-49cb-8a38-36a89023b787';
-  const username = 'user@example.com';
-  const userData = `{"Username":"${userId}","UserAttributes":[{"Name":"email_verified","Value":"true"},{"Name":"preferred_username","Value":"Carlos Curator"},{"Name":"email","Value":"${username}"},{"Name":"sub","Value":"${userId}"}],"UserCreateDate":"2022-03-07T11:43:13.000Z","UserLastModifiedDate":"2022-03-07T11:43:13.000Z","Enabled":true,"UserStatus":"CONFIRMED","MFAOptions":[],"UserMFASettingList":[],"ResponseMetadata":{"HTTPStatusCode":200,"HTTPHeaders":{"content-type":"text/html; charset=utf-8","content-length":"748","access-control-allow-origin":"*","access-control-allow-methods":"HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH","access-control-allow-headers":"authorization,content-type,content-length,content-md5,cache-control,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-target,x-amz-acl,x-amz-version-id,x-localstack-target,x-amz-tagging","access-control-expose-headers":"x-amz-version-id","connection":"close","date":"Mon, 07 Mar 2022 12:15:28 GMT","server":"hypercorn-h11"},"RetryAttempts":0}}`;
+const userConfig = {
+  contributor: {
+    userId: '1fd0998a-4168-4844-8475-de624f9be2cf',
+    username: 'author1@apt.com',
+    access: 'contributor',
+    name: 'Andre Author'
+  },
+  owner: {
+    userId: '33b94622-80c5-4443-8bb2-2e124219afea',
+    username: 'owner@apt.com',
+    access: 'contributor',
+    name: 'Olivia Owner'
+  },
+  curator: {
+    userId: '57a4c1c0-3802-4edc-a141-baeb5b18d50f',
+    username: 'curator@apt.com',
+    access: 'curator',
+    name: 'Carlos Curator'
+  }
+};
+
+Cypress.Commands.add('login', (role = 'contributor') => {
+  const { userId, username, access, name } = userConfig[role];
+  const userData = `{"Username":"${userId}","UserAttributes":[{"Name":"email_verified","Value":"true"},{"Name":"preferred_username","Value":"${name}"},{"Name":"email","Value":"${username}"},{"Name":"sub","Value":"${userId}"}],"UserCreateDate":"2022-03-07T11:43:13.000Z","UserLastModifiedDate":"2022-03-07T11:43:13.000Z","Enabled":true,"UserStatus":"CONFIRMED","MFAOptions":[],"UserMFASettingList":[],"ResponseMetadata":{"HTTPStatusCode":200,"HTTPHeaders":{"content-type":"text/html; charset=utf-8","content-length":"748","access-control-allow-origin":"*","access-control-allow-methods":"HEAD,GET,PUT,POST,DELETE,OPTIONS,PATCH","access-control-allow-headers":"authorization,content-type,content-length,content-md5,cache-control,x-amz-content-sha256,x-amz-date,x-amz-security-token,x-amz-user-agent,x-amz-target,x-amz-acl,x-amz-version-id,x-localstack-target,x-amz-tagging","access-control-expose-headers":"x-amz-version-id","connection":"close","date":"Mon, 07 Mar 2022 12:15:28 GMT","server":"hypercorn-h11"},"RetryAttempts":0}}`;
   const refreshToken = '3ff73baa';
 
-  // const user = userConfig[access];
   cy.intercept('POST', '/', userData);
   const keyPrefix = 'CognitoIdentityServiceProvider.abc123';
   const keyPrefixWithUsername = `${keyPrefix}.${username}`;


### PR DESCRIPTION
The PR adds tests for the following scenarios:

- Request a review
- Cancel a review
- Approve/Deny a review
- Conclude review
- Request publication
- Publish document

Also makes changes to the long command to

- set the correct user ids
- be able to select different user roles