### PR TITLE
Support DOI field when importing references from bibtex

### DIFF
--- a/app/assets/scripts/context/comment-center.js
+++ b/app/assets/scripts/context/comment-center.js
@@ -120,25 +120,42 @@ export const useCommentCenter = ({ atbd = null } = {}) => {
     reviewers
   ]);
 
+  const {
+    setAtbdId,
+    setAtbdVersion,
+    setContributors,
+    isPanelOpen,
+    openPanelOn
+  } = ctx;
+
   useEffectPrevious(
     (prev) => {
       if (!id || !version) return;
-      ctx.setAtbdId(id);
-      ctx.setAtbdVersion(version);
-      ctx.setContributors(contributors);
+      setAtbdId(id);
+      setAtbdVersion(version);
+      setContributors(contributors);
 
       // If the panel is open and the atbd changes update the values.
       // This happens when switching versions.
       const [prevId, prevVersion] = prev || [];
-      if ((prevId !== id || prevVersion !== version) && ctx.isPanelOpen) {
-        ctx.openPanelOn({
+      if ((prevId !== id || prevVersion !== version) && isPanelOpen) {
+        openPanelOn({
           // The atbdId must be numeric. The alias does not work.
           atbdId: id,
           atbdVersion: version
         });
       }
     },
-    [id, version, contributors, ctx.isPanelOpen, ctx.openPanelOn]
+    [
+      id,
+      version,
+      contributors,
+      setAtbdId,
+      setAtbdVersion,
+      setContributors,
+      isPanelOpen,
+      openPanelOn
+    ]
   );
 
   return ctx;

--- a/app/assets/scripts/utils/references.js
+++ b/app/assets/scripts/utils/references.js
@@ -249,11 +249,7 @@ export function parseBibtexFile(inputFile) {
         const input = new Cite(reader.result, { style: 'bibtex' });
 
         // Output as Bibtext JSON (default is CSL)
-        const items = input.get({
-          format: 'real',
-          type: 'json',
-          style: 'bibtex'
-        });
+        const items = input.format('biblatex', { type: 'object' });
 
         // Return properties
         resolve(items);


### PR DESCRIPTION
The api to get the values from the bibtex was not properly implemented and the DOI field was being excluded.
This PR changes the import format and api fixing the problem