### PR TITLE
Dockerize the ui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build and publish docker image
+
+on:
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - "adr/**"
+      - "cypress/**"
+      - "docs/**"
+      - ".vscode/**"
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build development image
+        run: docker build -t ghcr.io/NASA-IMPACT/nasa-apt-frontend:develop .
+
+      - name: Push docker image
+        run: docker push ghcr.io/NASA-IMPACT/nasa-apt-frontend:develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:14-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN mkdir /apt-frontend
+WORKDIR /apt-frontend
+
+COPY .prettierrc /apt-frontend/.prettierrc
+COPY .npmrc /apt-frontend/.npmrc
+COPY package.json /apt-frontend
+COPY yarn.lock /apt-frontend
+COPY gulpfile.js /apt-frontend
+COPY posthtml.config.js /apt-frontend
+COPY .parcelrc /apt-frontend
+COPY gulp-help-pages.js /apt-frontend
+
+
+COPY app /apt-frontend/app
+COPY content /apt-frontend/content
+COPY static /apt-frontend/static
+
+RUN yarn install
+
+CMD ["yarn", "serve"]


### PR DESCRIPTION
Add a Dockerfile and a GitHub action to build and push the docker image to the GitHub container registry.

As part of the new PDF generation process in https://github.com/NASA-IMPACT/nasa-apt/pull/638, we run the frontend as a docker-compose service in the development environment. Uploading a docker image of the frontend to Github's container registry ensures that we can pull and use an existing image instead of having to build the frontend image locally for backend development.