### PR TITLE
Get rid of forced page breaks after headers

### DIFF
--- a/static/pdf-preview-styles.css
+++ b/static/pdf-preview-styles.css
@@ -9,7 +9,3 @@
     content: counter(page);
   }
 }
-
-h2 {
-  break-before: page;
-}


### PR DESCRIPTION
Addresses the page breaks issue from https://github.com/NASA-IMPACT/nasa-apt/issues/642
