### PR TITLE
Make the toasts a bit less awkward

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -46,10 +46,13 @@ export default function DocumentDownloadMenu(props) {
     const pdfFileName = `${alias}-v${version}.pdf`;
     const maxRetries = 10;
     const waitBetweenTries = 5000;
+    const toast = createProcessToast('Downloading PDF, please wait...');
     let retryCount = 0;
 
     async function fetchPdf(url) {
-      const toast = createProcessToast('Downloading PDF, please wait...');
+      if (retryCount > 0) {
+        toast.update('Generating the PDF. This may take a minute...');
+      }
       const user = await Auth.currentAuthenticatedUser();
       if (!user) {
         toast.error('Failed to download PDF! (Not authenticated)');
@@ -98,7 +101,7 @@ export default function DocumentDownloadMenu(props) {
           const result = await response.json();
 
           if (result?.message) {
-            toast.success(result.message);
+            toast.update(result.message);
           }
 
           setTimeout(() => {


### PR DESCRIPTION
Makes sure that while downloading a PDF, the toasts don't stack up like this:
![image](https://user-images.githubusercontent.com/1142203/221160714-4649afdf-cc37-4ce2-bb7a-05f3f44842ce.png)
