### PR TITLE
lowercase organization name for docker repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build development image
-        run: docker build -t ghcr.io/NASA-IMPACT/nasa-apt-frontend:develop .
+        run: docker build -t ghcr.io/nasa-impact/nasa-apt-frontend:develop .
 
       - name: Push docker image
-        run: docker push ghcr.io/NASA-IMPACT/nasa-apt-frontend:develop
+        run: docker push ghcr.io/nasa-impact/nasa-apt-frontend:develop


### PR DESCRIPTION
fixes the [failing docker build](https://github.com/NASA-IMPACT/nasa-apt-frontend/actions/runs/4465565353/jobs/7842749413#step:4:5) by making `NASA-IMPACT` lowercase. 