### PR TITLE
Fix npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=http://ec2-3-82-125-171.compute-1.amazonaws.com:4873

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,14 +4,14 @@
 
 "@ampproject/remapping@^2.1.0":
   version "2.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@ampproject%2fremapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
+  resolved "https://registry.yarnpkg.com/@ampproject%2fremapping/-/remapping-2.1.2.tgz#4edca94973ded9630d20101cd8559cedb8d8bd34"
   integrity sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
 "@aws-amplify/analytics@5.0.3":
   version "5.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fanalytics/-/analytics-5.0.3.tgz#ac5e3c9b6451b6b03fc9bbda952f3407f13aea53"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fanalytics/-/analytics-5.0.3.tgz#ac5e3c9b6451b6b03fc9bbda952f3407f13aea53"
   integrity sha512-ynBU/AU6wnh7J0GjlT3yzj6owl0VJbmOCieeLSkXsninRVO1VghgQlMzHmz9Tr16MulEYaXZrHQzUz85tJ1NFA==
   dependencies:
     "@aws-amplify/cache" "4.0.5"
@@ -26,7 +26,7 @@
 
 "@aws-amplify/api-graphql@2.0.3":
   version "2.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fapi-graphql/-/api-graphql-2.0.3.tgz#4c510fa1e7062d78839f065f02416ec10446f6e0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fapi-graphql/-/api-graphql-2.0.3.tgz#4c510fa1e7062d78839f065f02416ec10446f6e0"
   integrity sha512-m2M0+yodKumt+vdhAZ6xFRnW07O1OBARHMDkqsTKQF+2SfNR3JO4OvC5O2rvDrQEeE0W8QAA4Ap7AGlxu4xvmA==
   dependencies:
     "@aws-amplify/api-rest" "2.0.3"
@@ -40,7 +40,7 @@
 
 "@aws-amplify/api-rest@2.0.3":
   version "2.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fapi-rest/-/api-rest-2.0.3.tgz#74065171268c7e99aaca74eb0ef82e652504ff47"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fapi-rest/-/api-rest-2.0.3.tgz#74065171268c7e99aaca74eb0ef82e652504ff47"
   integrity sha512-Qw9Dt9yBiEnuyGufuuzkIoY1L5eyeE7CVQDnK59kmbL0YB8/8Lb7CQswrbdo4L32LN1mmUzboHgkK9ZaBHBgzA==
   dependencies:
     "@aws-amplify/core" "4.1.1"
@@ -48,7 +48,7 @@
 
 "@aws-amplify/api@4.0.3":
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fapi/-/api-4.0.3.tgz#29fb6dc542ccdabf31bb4b8e657a60dcb746a8f7"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fapi/-/api-4.0.3.tgz#29fb6dc542ccdabf31bb4b8e657a60dcb746a8f7"
   integrity sha512-2WfdA5NPmypK1bHQL1ZjAWCqVKfXGMnCavW/NEJw9amjsJ4bwsHzsb2xf0pAHl+Nd/gJjhgXRTvBgZI3dCm/Wg==
   dependencies:
     "@aws-amplify/api-graphql" "2.0.3"
@@ -56,7 +56,7 @@
 
 "@aws-amplify/auth@4.0.3":
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fauth/-/auth-4.0.3.tgz#fa873baa96c634941a886a44611cbdeb61a4dbe7"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fauth/-/auth-4.0.3.tgz#fa873baa96c634941a886a44611cbdeb61a4dbe7"
   integrity sha512-eMoxeuVhM+zAjIsXnijTfV+U2dW44vuLqBFLAKUHjqx0bBakA19HNJncYOFAredgLqywPZX3ZENlcKw/jv9OVA==
   dependencies:
     "@aws-amplify/cache" "4.0.5"
@@ -66,14 +66,14 @@
 
 "@aws-amplify/cache@4.0.5":
   version "4.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fcache/-/cache-4.0.5.tgz#b95c140af521b27ea42f771e6c4baf607c55145a"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fcache/-/cache-4.0.5.tgz#b95c140af521b27ea42f771e6c4baf607c55145a"
   integrity sha512-nRh0LbJSiTmZCsANRMfhsiABfo6oDEoYkAHyFqJVNb1yHgvyv1E7TCmkZ8/6+pDmvFerEB1FzAHKpyWiwAGuzg==
   dependencies:
     "@aws-amplify/core" "4.1.1"
 
 "@aws-amplify/core@4.1.1":
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fcore/-/core-4.1.1.tgz#01a509da5f22832c841b020e2ec2af4de6a40ccd"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fcore/-/core-4.1.1.tgz#01a509da5f22832c841b020e2ec2af4de6a40ccd"
   integrity sha512-Bery/Yo+PGjBr50JIbJLyXEePP2wU56aFQz1r+oA/7713BnFm/AMWwFCQ3Ih19jdBitEDlsEjQ9a+5y5l9Emiw==
   dependencies:
     "@aws-crypto/sha256-js" "1.0.0-alpha.0"
@@ -86,7 +86,7 @@
 
 "@aws-amplify/datastore@3.1.1":
   version "3.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fdatastore/-/datastore-3.1.1.tgz#675ee463d94d6e966d2a34ae7740d7632d7c24ae"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fdatastore/-/datastore-3.1.1.tgz#675ee463d94d6e966d2a34ae7740d7632d7c24ae"
   integrity sha512-oTWY6g5/CLrBCMHQ/VZDUkCjX7VTh/SBBCENrrAEoCyors7zgFmG0JUochc5OqGFNHSA3VIZfXICdFxb08f5dQ==
   dependencies:
     "@aws-amplify/api" "4.0.3"
@@ -103,7 +103,7 @@
 
 "@aws-amplify/interactions@4.0.3":
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2finteractions/-/interactions-4.0.3.tgz#44c58d2670a02b4a0cead5c89b844d2b5bc0c197"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2finteractions/-/interactions-4.0.3.tgz#44c58d2670a02b4a0cead5c89b844d2b5bc0c197"
   integrity sha512-sobF1RHgosZNz08AfXciuAepHnAM9pjRwQ6pxwot8BEZUHroE7f6q8boKaJEsLB+nikwaFFouP2c2cK+f7VAsQ==
   dependencies:
     "@aws-amplify/core" "4.1.1"
@@ -111,7 +111,7 @@
 
 "@aws-amplify/predictions@4.0.3":
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fpredictions/-/predictions-4.0.3.tgz#821046b441de93d10c93862f44ef88799bfb37a0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fpredictions/-/predictions-4.0.3.tgz#821046b441de93d10c93862f44ef88799bfb37a0"
   integrity sha512-sTd1Jh6VL2zHy8wjaHSyGvpBfiNVG6P8zldOoOeV/+fiIjfTcIQWciTYtMXKC09N6++GsaPSlAyId1749ix7dw==
   dependencies:
     "@aws-amplify/core" "4.1.1"
@@ -127,7 +127,7 @@
 
 "@aws-amplify/pubsub@4.0.3":
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fpubsub/-/pubsub-4.0.3.tgz#b7874657e182b085866c2db62e7bd1b0681dfa2a"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fpubsub/-/pubsub-4.0.3.tgz#b7874657e182b085866c2db62e7bd1b0681dfa2a"
   integrity sha512-EozqSpwv2Dd1caIgW0dloskUiRfdaJplCJjVKoiHedWgxiQCxwkeHg/3LW0OoTbq01EiVYhMMXqvTS12sPIxIQ==
   dependencies:
     "@aws-amplify/auth" "4.0.3"
@@ -140,7 +140,7 @@
 
 "@aws-amplify/storage@4.2.0":
   version "4.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fstorage/-/storage-4.2.0.tgz#ac62db3a50834c5ef19f1832256fd6597fafb64d"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fstorage/-/storage-4.2.0.tgz#ac62db3a50834c5ef19f1832256fd6597fafb64d"
   integrity sha512-w7nFdXggjwOx18ZJNHBpyJ4HTNXZxKjA6IJdiVYqMuwd4qzmGjESbkhu5Oi1i401IoNQuV1b3kHxyIvu4JhJgQ==
   dependencies:
     "@aws-amplify/core" "4.1.1"
@@ -154,33 +154,33 @@
 
 "@aws-amplify/ui@2.0.3":
   version "2.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fui/-/ui-2.0.3.tgz#7a88a416942aedbc6a6ea9850a2c98693c80340a"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fui/-/ui-2.0.3.tgz#7a88a416942aedbc6a6ea9850a2c98693c80340a"
   integrity sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A==
 
 "@aws-amplify/xr@3.0.3":
   version "3.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-amplify%2fxr/-/xr-3.0.3.tgz#baa9b3ead011b183dc7705da65536ee7a9763cf6"
+  resolved "https://registry.yarnpkg.com/@aws-amplify%2fxr/-/xr-3.0.3.tgz#baa9b3ead011b183dc7705da65536ee7a9763cf6"
   integrity sha512-VE3GvBwzrg4AvDpa8tmiH/zAPA1jchVycG162VwEpH2JH5mC85VzdeRdGpm1dpuxyXrPlP0u+xIG/JsRlKHlkA==
   dependencies:
     "@aws-amplify/core" "4.1.1"
 
 "@aws-crypto/crc32@^1.0.0":
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fcrc32/-/crc32-1.0.0.tgz#6a0164fd92bb365860ba6afb5dfef449701eb8ca"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fcrc32/-/crc32-1.0.0.tgz#6a0164fd92bb365860ba6afb5dfef449701eb8ca"
   integrity sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==
   dependencies:
     tslib "^1.11.1"
 
 "@aws-crypto/ie11-detection@^1.0.0":
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fie11-detection/-/ie11-detection-1.0.0.tgz#d3a6af29ba7f15458f79c41d1cd8cac3925e726a"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fie11-detection/-/ie11-detection-1.0.0.tgz#d3a6af29ba7f15458f79c41d1cd8cac3925e726a"
   integrity sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==
   dependencies:
     tslib "^1.11.1"
 
 "@aws-crypto/sha256-browser@^1.0.0":
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fsha256-browser/-/sha256-browser-1.1.0.tgz#20092cc6c08d8f04db0ed57b6f05cff150384f77"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fsha256-browser/-/sha256-browser-1.1.0.tgz#20092cc6c08d8f04db0ed57b6f05cff150384f77"
   integrity sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==
   dependencies:
     "@aws-crypto/ie11-detection" "^1.0.0"
@@ -193,7 +193,7 @@
 
 "@aws-crypto/sha256-js@1.0.0-alpha.0":
   version "1.0.0-alpha.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fsha256-js/-/sha256-js-1.0.0-alpha.0.tgz#1146f6fa823001a9065ce60db5bf1afcc7c1cc3a"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fsha256-js/-/sha256-js-1.0.0-alpha.0.tgz#1146f6fa823001a9065ce60db5bf1afcc7c1cc3a"
   integrity sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==
   dependencies:
     "@aws-sdk/types" "^1.0.0-alpha.0"
@@ -202,7 +202,7 @@
 
 "@aws-crypto/sha256-js@^1.0.0", "@aws-crypto/sha256-js@^1.1.0":
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fsha256-js/-/sha256-js-1.1.0.tgz#a58386ad18186e392e0f1d98d18831261d27b071"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fsha256-js/-/sha256-js-1.1.0.tgz#a58386ad18186e392e0f1d98d18831261d27b071"
   integrity sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==
   dependencies:
     "@aws-sdk/types" "^3.1.0"
@@ -211,14 +211,14 @@
 
 "@aws-crypto/supports-web-crypto@^1.0.0":
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-crypto%2fsupports-web-crypto/-/supports-web-crypto-1.0.0.tgz#c40901bc17ac1e875e248df16a2b47ad8bfd9a93"
+  resolved "https://registry.yarnpkg.com/@aws-crypto%2fsupports-web-crypto/-/supports-web-crypto-1.0.0.tgz#c40901bc17ac1e875e248df16a2b47ad8bfd9a93"
   integrity sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==
   dependencies:
     tslib "^1.11.1"
 
 "@aws-sdk/abort-controller@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fabort-controller/-/abort-controller-3.6.1.tgz#75812875bbef6ad17e0e3a6d96aab9df636376f9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fabort-controller/-/abort-controller-3.6.1.tgz#75812875bbef6ad17e0e3a6d96aab9df636376f9"
   integrity sha512-X81XkxX/2Tvv9YNcEto/rcQzPIdKJHFSnl9hBl/qkSdCFV/GaQ2XNWfKm5qFXMLlZNFS0Fn5CnBJ83qnBm47vg==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -226,7 +226,7 @@
 
 "@aws-sdk/chunked-blob-reader-native@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fchunked-blob-reader-native/-/chunked-blob-reader-native-3.6.1.tgz#21c2c8773c3cd8403c2a953fd0e9e4f69c120214"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fchunked-blob-reader-native/-/chunked-blob-reader-native-3.6.1.tgz#21c2c8773c3cd8403c2a953fd0e9e4f69c120214"
   integrity sha512-vP6bc2v9h442Srmo7t2QcIbPjk5IqLSf4jGnKDAes8z+7eyjCtKugRP3lOM1fJCfGlPIsJGYnexxYdEGw008vA==
   dependencies:
     "@aws-sdk/util-base64-browser" "3.6.1"
@@ -234,14 +234,14 @@
 
 "@aws-sdk/chunked-blob-reader@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fchunked-blob-reader/-/chunked-blob-reader-3.6.1.tgz#63363025dcecc2f9dd47ae5c282d79c01b327d82"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fchunked-blob-reader/-/chunked-blob-reader-3.6.1.tgz#63363025dcecc2f9dd47ae5c282d79c01b327d82"
   integrity sha512-QBGUBoD8D5nsM/EKoc0rjpApa5NE5pQVzw1caE8sG00QMMPkCXWSB/gTVKVY0GOAhJFoA/VpVPQchIlZcOrBFg==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/client-cognito-identity@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-cognito-identity/-/client-cognito-identity-3.6.1.tgz#36992a4fef7eff1f2b1dbee30850e30ebdfc15bb"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-cognito-identity/-/client-cognito-identity-3.6.1.tgz#36992a4fef7eff1f2b1dbee30850e30ebdfc15bb"
   integrity sha512-FMj2GR9R5oCKb3/NI16GIvWeHcE4uX42fBAaQKPbjg2gALFDx9CcJYsdOtDP37V89GtPyZilLv6GJxrwJKzYGg==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -278,7 +278,7 @@
 
 "@aws-sdk/client-comprehend@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-comprehend/-/client-comprehend-3.6.1.tgz#d640d510b49feafa94ac252cdd7942cbe5537249"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-comprehend/-/client-comprehend-3.6.1.tgz#d640d510b49feafa94ac252cdd7942cbe5537249"
   integrity sha512-Y2ixlSTjjAp2HJhkUArtYqC/X+zG5Qqu3Bl+Ez22u4u4YnG8HsNFD6FE1axuWSdSa5AFtWTEt+Cz2Ghj/tDySA==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -316,7 +316,7 @@
 
 "@aws-sdk/client-firehose@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-firehose/-/client-firehose-3.6.1.tgz#87a8ef0c18267907b3ce712e6d3de8f36b0a7c7b"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-firehose/-/client-firehose-3.6.1.tgz#87a8ef0c18267907b3ce712e6d3de8f36b0a7c7b"
   integrity sha512-KhiKCm+cJmnRFuAEyO3DBpFVDNix1XcVikdxk2lvYbFWkM1oUZoBpudxaJ+fPf2W3stF3CXIAOP+TnGqSZCy9g==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -353,7 +353,7 @@
 
 "@aws-sdk/client-kinesis@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-kinesis/-/client-kinesis-3.6.1.tgz#48583cc854f9108bc8ff6168005d9a05b24bae31"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-kinesis/-/client-kinesis-3.6.1.tgz#48583cc854f9108bc8ff6168005d9a05b24bae31"
   integrity sha512-Ygo+92LxHeUZmiyhiHT+k7hIOhJd6S7ckCEVUsQs2rfwe9bAygUY/3cCoZSqgWy7exFRRKsjhzStcyV6i6jrVQ==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -394,7 +394,7 @@
 
 "@aws-sdk/client-lex-runtime-service@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-lex-runtime-service/-/client-lex-runtime-service-3.6.1.tgz#43290057858a60b7465989d63c2824512e8166d2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-lex-runtime-service/-/client-lex-runtime-service-3.6.1.tgz#43290057858a60b7465989d63c2824512e8166d2"
   integrity sha512-xi3m3f3G9KEKdziOFyynkfvN7OzdT9T8V3wkM4x+Zhid9v1K4Rg7OvbBb5oG9UicLz54tcZGkt0VN4ldEB/XLQ==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -431,7 +431,7 @@
 
 "@aws-sdk/client-personalize-events@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-personalize-events/-/client-personalize-events-3.6.1.tgz#86942bb64108cfc2f6c31a8b54aab6fa7f7be00f"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-personalize-events/-/client-personalize-events-3.6.1.tgz#86942bb64108cfc2f6c31a8b54aab6fa7f7be00f"
   integrity sha512-x9Jl/7emSQsB6GwBvjyw5BiSO26CnH4uvjNit6n54yNMtJ26q0+oIxkplnUDyjLTfLRe373c/z5/4dQQtDffkw==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -468,7 +468,7 @@
 
 "@aws-sdk/client-pinpoint@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-pinpoint/-/client-pinpoint-3.6.1.tgz#6b93f46475ae2667d77053be51ea62f52e330155"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-pinpoint/-/client-pinpoint-3.6.1.tgz#6b93f46475ae2667d77053be51ea62f52e330155"
   integrity sha512-dueBedp91EKAHxcWLR3aNx/eUEdxdF9niEQTzOO2O4iJL2yvO2Hh7ZYiO7B3g7FuuICTpWSHd//Y9mGmSVLMCg==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -505,7 +505,7 @@
 
 "@aws-sdk/client-polly@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-polly/-/client-polly-3.6.1.tgz#869deb186e57fca29737bfa7af094599d7879841"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-polly/-/client-polly-3.6.1.tgz#869deb186e57fca29737bfa7af094599d7879841"
   integrity sha512-y6fxVYndGS7z2KqHViPCqagBEOsZlxBUYUJZuD6WWTiQrI0Pwe5qG02oKJVaa5OmxE20QLf6bRBWj2rQpeF4IQ==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -542,7 +542,7 @@
 
 "@aws-sdk/client-rekognition@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-rekognition/-/client-rekognition-3.6.1.tgz#710ba6d4509a2caa417cf0702ba81b5b65aa73eb"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-rekognition/-/client-rekognition-3.6.1.tgz#710ba6d4509a2caa417cf0702ba81b5b65aa73eb"
   integrity sha512-Ia4FEog9RrI0IoDRbOJO6djwhVAAaEZutxEKrWbjrVz4bgib28L+V+yAio2SUneeirj8pNYXwBKPfoYOUqGHhA==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -580,7 +580,7 @@
 
 "@aws-sdk/client-s3@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-s3/-/client-s3-3.6.1.tgz#aab1e0e92b353d9d51152d9347b7e1809f3593d0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-s3/-/client-s3-3.6.1.tgz#aab1e0e92b353d9d51152d9347b7e1809f3593d0"
   integrity sha512-59cTmZj92iwgNoAeJirK5sZNQNXLc/oI3luqrEHRNLuOh70bjdgad70T0a5k2Ysd/v/QNamqJxnCJMPuX1bhgw==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -632,7 +632,7 @@
 
 "@aws-sdk/client-textract@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-textract/-/client-textract-3.6.1.tgz#b8972f53f0353222b4c052adc784291e602be6aa"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-textract/-/client-textract-3.6.1.tgz#b8972f53f0353222b4c052adc784291e602be6aa"
   integrity sha512-nLrBzWDt3ToiGVFF4lW7a/eZpI2zjdvu7lwmOWyXX8iiPzhBVVEfd5oOorRyJYBsGMslp4sqV8TBkU5Ld/a97Q==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -669,7 +669,7 @@
 
 "@aws-sdk/client-translate@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fclient-translate/-/client-translate-3.6.1.tgz#ce855c9fe7885b930d4039c2e45c869e3c0a6656"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fclient-translate/-/client-translate-3.6.1.tgz#ce855c9fe7885b930d4039c2e45c869e3c0a6656"
   integrity sha512-RIHY+Og1i43B5aWlfUUk0ZFnNfM7j2vzlYUwOqhndawV49GFf96M3pmskR5sKEZI+5TXY77qR9TgZ/r3UxVCRQ==
   dependencies:
     "@aws-crypto/sha256-browser" "^1.0.0"
@@ -707,7 +707,7 @@
 
 "@aws-sdk/config-resolver@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fconfig-resolver/-/config-resolver-3.6.1.tgz#3bcc5e6a0ebeedf0981b0540e1f18a72b4dafebf"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fconfig-resolver/-/config-resolver-3.6.1.tgz#3bcc5e6a0ebeedf0981b0540e1f18a72b4dafebf"
   integrity sha512-qjP1g3jLIm+XvOIJ4J7VmZRi87vsDmTRzIFePVeG+EFWwYQLxQjTGMdIj3yKTh1WuZ0HByf47mGcpiS4HZLm1Q==
   dependencies:
     "@aws-sdk/signature-v4" "3.6.1"
@@ -716,7 +716,7 @@
 
 "@aws-sdk/credential-provider-cognito-identity@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz#df928951612a34832c2df15fb899251d828c2df3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz#df928951612a34832c2df15fb899251d828c2df3"
   integrity sha512-uJ9q+yq+Dhdo32gcv0p/AT7sKSAUH0y4ts9XRK/vx0dW9Q3XJy99mOJlq/6fkh4LfWeavJJlaCo9lSHNMWXx4w==
   dependencies:
     "@aws-sdk/client-cognito-identity" "3.6.1"
@@ -726,7 +726,7 @@
 
 "@aws-sdk/credential-provider-env@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-env/-/credential-provider-env-3.6.1.tgz#d8b2dd36836432a9b8ec05a5cf9fe428b04c9964"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-env/-/credential-provider-env-3.6.1.tgz#d8b2dd36836432a9b8ec05a5cf9fe428b04c9964"
   integrity sha512-coeFf/HnhpGidcAN1i1NuFgyFB2M6DeN1zNVy4f6s4mAh96ftr9DgWM1CcE3C+cLHEdpNqleVgC/2VQpyzOBLQ==
   dependencies:
     "@aws-sdk/property-provider" "3.6.1"
@@ -735,7 +735,7 @@
 
 "@aws-sdk/credential-provider-imds@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-imds/-/credential-provider-imds-3.6.1.tgz#b5a8b8ef15eac26c58e469451a6c7c34ab3ca875"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-imds/-/credential-provider-imds-3.6.1.tgz#b5a8b8ef15eac26c58e469451a6c7c34ab3ca875"
   integrity sha512-bf4LMI418OYcQbyLZRAW8Q5AYM2IKrNqOnIcfrFn2f17ulG7TzoWW3WN/kMOw4TC9+y+vIlCWOv87GxU1yP0Bg==
   dependencies:
     "@aws-sdk/property-provider" "3.6.1"
@@ -744,7 +744,7 @@
 
 "@aws-sdk/credential-provider-ini@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-ini/-/credential-provider-ini-3.6.1.tgz#0da6d9341e621f8e0815814ed017b88e268fbc3d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-ini/-/credential-provider-ini-3.6.1.tgz#0da6d9341e621f8e0815814ed017b88e268fbc3d"
   integrity sha512-3jguW6+ttRNddRZvbrs1yb3F1jrUbqyv0UfRoHuOGthjTt+L9sDpJaJGugYnT3bS9WBu1NydLVE2kDV++mJGVw==
   dependencies:
     "@aws-sdk/property-provider" "3.6.1"
@@ -754,7 +754,7 @@
 
 "@aws-sdk/credential-provider-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-node/-/credential-provider-node-3.6.1.tgz#0055292a4f0f49d053e8dfcc9174d8d2cf6862bb"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-node/-/credential-provider-node-3.6.1.tgz#0055292a4f0f49d053e8dfcc9174d8d2cf6862bb"
   integrity sha512-VAHOcsqkPrF1k/fA62pv9c75lUWe5bHpcbFX83C3EUPd2FXV10Lfkv6bdWhyZPQy0k8T+9/yikHH3c7ZQeFE5A==
   dependencies:
     "@aws-sdk/credential-provider-env" "3.6.1"
@@ -768,7 +768,7 @@
 
 "@aws-sdk/credential-provider-process@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fcredential-provider-process/-/credential-provider-process-3.6.1.tgz#5bf851f3ee232c565b8c82608926df0ad28c1958"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fcredential-provider-process/-/credential-provider-process-3.6.1.tgz#5bf851f3ee232c565b8c82608926df0ad28c1958"
   integrity sha512-d0/TpMoEV4qMYkdpyyjU2Otse9X2jC1DuxWajHOWZYEw8oejMvXYTZ10hNaXZvAcNM9q214rp+k4mkt6gIcI6g==
   dependencies:
     "@aws-sdk/credential-provider-ini" "3.6.1"
@@ -779,7 +779,7 @@
 
 "@aws-sdk/eventstream-marshaller@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2feventstream-marshaller/-/eventstream-marshaller-3.6.1.tgz#6abfbdf3639249d1a77686cbcae5d8e47bcba989"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2feventstream-marshaller/-/eventstream-marshaller-3.6.1.tgz#6abfbdf3639249d1a77686cbcae5d8e47bcba989"
   integrity sha512-ZvN3Nvxn2Gul08L9MOSN123LwSO0E1gF/CqmOGZtEWzPnoSX/PWM9mhPPeXubyw2KdlXylOodYYw3EAATk3OmA==
   dependencies:
     "@aws-crypto/crc32" "^1.0.0"
@@ -789,7 +789,7 @@
 
 "@aws-sdk/eventstream-serde-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2feventstream-serde-browser/-/eventstream-serde-browser-3.6.1.tgz#1253bd5215745f79d534fc9bc6bd006ee7a0f239"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2feventstream-serde-browser/-/eventstream-serde-browser-3.6.1.tgz#1253bd5215745f79d534fc9bc6bd006ee7a0f239"
   integrity sha512-J8B30d+YUfkBtgWRr7+9AfYiPnbG28zjMlFGsJf8Wxr/hDCfff+Z8NzlBYFEbS7McXXhRiIN8DHUvCtolJtWJQ==
   dependencies:
     "@aws-sdk/eventstream-marshaller" "3.6.1"
@@ -799,7 +799,7 @@
 
 "@aws-sdk/eventstream-serde-config-resolver@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2feventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.6.1.tgz#ebb5c1614f55d0ebb225defac1f76c420e188086"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2feventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.6.1.tgz#ebb5c1614f55d0ebb225defac1f76c420e188086"
   integrity sha512-72pCzcT/KeD4gPgRVBSQzEzz4JBim8bNwPwZCGaIYdYAsAI8YMlvp0JNdis3Ov9DFURc87YilWKQlAfw7CDJxA==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -807,7 +807,7 @@
 
 "@aws-sdk/eventstream-serde-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2feventstream-serde-node/-/eventstream-serde-node-3.6.1.tgz#705e12bea185905a198d7812af10e3a679dfc841"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2feventstream-serde-node/-/eventstream-serde-node-3.6.1.tgz#705e12bea185905a198d7812af10e3a679dfc841"
   integrity sha512-rjBbJFjCrEcm2NxZctp+eJmyPxKYayG3tQZo8PEAQSViIlK5QexQI3fgqNAeCtK7l/SFAAvnOMRZF6Z3NdUY6A==
   dependencies:
     "@aws-sdk/eventstream-marshaller" "3.6.1"
@@ -817,7 +817,7 @@
 
 "@aws-sdk/eventstream-serde-universal@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2feventstream-serde-universal/-/eventstream-serde-universal-3.6.1.tgz#5be6865adb55436cbc90557df3a3c49b53553470"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2feventstream-serde-universal/-/eventstream-serde-universal-3.6.1.tgz#5be6865adb55436cbc90557df3a3c49b53553470"
   integrity sha512-rpRu97yAGHr9GQLWMzcGICR2PxNu1dHU/MYc9Kb6UgGeZd4fod4o1zjhAJuj98cXn2xwHNFM4wMKua6B4zKrZg==
   dependencies:
     "@aws-sdk/eventstream-marshaller" "3.6.1"
@@ -826,7 +826,7 @@
 
 "@aws-sdk/fetch-http-handler@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2ffetch-http-handler/-/fetch-http-handler-3.6.1.tgz#c5fb4a4ee158161fca52b220d2c11dddcda9b092"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2ffetch-http-handler/-/fetch-http-handler-3.6.1.tgz#c5fb4a4ee158161fca52b220d2c11dddcda9b092"
   integrity sha512-N8l6ZbwhINuWG5hsl625lmIQmVjzsqRPmlgh061jm5D90IhsM5/3A3wUxpB/k0av1dmuMRw/m0YtBU5w4LOwvw==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -837,7 +837,7 @@
 
 "@aws-sdk/hash-blob-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fhash-blob-browser/-/hash-blob-browser-3.6.1.tgz#f44a1857b75769e21cd6091211171135e03531e6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fhash-blob-browser/-/hash-blob-browser-3.6.1.tgz#f44a1857b75769e21cd6091211171135e03531e6"
   integrity sha512-9jPaZ/e3F8gf9JZd44DD6MvbYV6bKnn99rkG3GFIINOy9etoxPrLehp2bH2DK/j0ow60RNuwgUjj5qHV/zF67g==
   dependencies:
     "@aws-sdk/chunked-blob-reader" "3.6.1"
@@ -847,7 +847,7 @@
 
 "@aws-sdk/hash-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fhash-node/-/hash-node-3.6.1.tgz#72d75ec3b9c7e7f9b0c498805364f1f897165ce9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fhash-node/-/hash-node-3.6.1.tgz#72d75ec3b9c7e7f9b0c498805364f1f897165ce9"
   integrity sha512-iKEpzpyaG9PYCnaOGwTIf0lffsF/TpsXrzAfnBlfeOU/3FbgniW2z/yq5xBbtMDtLobtOYC09kUFwDnDvuveSA==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -856,7 +856,7 @@
 
 "@aws-sdk/hash-stream-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fhash-stream-node/-/hash-stream-node-3.6.1.tgz#91c77e382ef3d0472160a49b1109395a4a70c801"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fhash-stream-node/-/hash-stream-node-3.6.1.tgz#91c77e382ef3d0472160a49b1109395a4a70c801"
   integrity sha512-ePaWjCItIWxuSxA/UnUM/keQ3IAOsQz3FYSxu0KK8K0e1bKTEUgDIG9oMLBq7jIl9TzJG0HBXuPfMe73QHUNug==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -864,7 +864,7 @@
 
 "@aws-sdk/invalid-dependency@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2finvalid-dependency/-/invalid-dependency-3.6.1.tgz#fd2519f5482c6d6113d38a73b7143fd8d5b5b670"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2finvalid-dependency/-/invalid-dependency-3.6.1.tgz#fd2519f5482c6d6113d38a73b7143fd8d5b5b670"
   integrity sha512-d0RLqK7yeDCZJKopnGmGXo2rYkQNE7sGKVmBHQD1j1kKZ9lWwRoJeWqo834JNPZzY5XRvZG5SuIjJ1kFy8LpyQ==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -872,14 +872,14 @@
 
 "@aws-sdk/is-array-buffer@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fis-array-buffer/-/is-array-buffer-3.6.1.tgz#96df5d64b2d599947f81b164d5d92623f85c659c"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fis-array-buffer/-/is-array-buffer-3.6.1.tgz#96df5d64b2d599947f81b164d5d92623f85c659c"
   integrity sha512-qm2iDJmCrxlQE2dsFG+TujPe7jw4DF+4RTrsFMhk/e3lOl3MAzQ6Fc2kXtgeUcVrZVFTL8fQvXE1ByYyI6WbCw==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/md5-js@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmd5-js/-/md5-js-3.6.1.tgz#bffe21106fba0174d73ccc2c29ca1c5364d2af2d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmd5-js/-/md5-js-3.6.1.tgz#bffe21106fba0174d73ccc2c29ca1c5364d2af2d"
   integrity sha512-lzCqkZF1sbzGFDyq1dI+lR3AmlE33rbC/JhZ5fzw3hJZvfZ6Beq3Su7YwDo65IWEu0zOKYaNywTeOloXP/CkxQ==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -888,7 +888,7 @@
 
 "@aws-sdk/middleware-apply-body-checksum@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-apply-body-checksum/-/middleware-apply-body-checksum-3.6.1.tgz#dece86e489531981b8aa2786dafbbef69edce1d6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-apply-body-checksum/-/middleware-apply-body-checksum-3.6.1.tgz#dece86e489531981b8aa2786dafbbef69edce1d6"
   integrity sha512-IncmXR1MPk6aYvmD37It8dP6wVMzaxxzgrkIU2ACkN5UVwA+/0Sr3ZNd9dNwjpyoH1AwpL9BetnlJaWtT6K5ew==
   dependencies:
     "@aws-sdk/is-array-buffer" "3.6.1"
@@ -898,7 +898,7 @@
 
 "@aws-sdk/middleware-bucket-endpoint@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-bucket-endpoint/-/middleware-bucket-endpoint-3.6.1.tgz#7ebdd79fac0f78d8af549f4fd799d4f7d02e78de"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-bucket-endpoint/-/middleware-bucket-endpoint-3.6.1.tgz#7ebdd79fac0f78d8af549f4fd799d4f7d02e78de"
   integrity sha512-Frcqn2RQDNHy+e2Q9hv3ejT3mQWtGlfZESbXEF6toR4M0R8MmEVqIB/ohI6VKBj11lRmGwvpPsR6zz+PJ8HS7A==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -908,7 +908,7 @@
 
 "@aws-sdk/middleware-content-length@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-content-length/-/middleware-content-length-3.6.1.tgz#f9c00a4045b2b56c1ff8bcbb3dec9c3d42332992"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-content-length/-/middleware-content-length-3.6.1.tgz#f9c00a4045b2b56c1ff8bcbb3dec9c3d42332992"
   integrity sha512-QRcocG9f5YjYzbjs2HjKla6ZIjvx8Y8tm1ZSFOPey81m18CLif1O7M3AtJXvxn+0zeSck9StFdhz5gfjVNYtDg==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -917,7 +917,7 @@
 
 "@aws-sdk/middleware-expect-continue@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-expect-continue/-/middleware-expect-continue-3.6.1.tgz#56e56db572f81dd4fa8803e85bd1f36005f9fffa"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-expect-continue/-/middleware-expect-continue-3.6.1.tgz#56e56db572f81dd4fa8803e85bd1f36005f9fffa"
   integrity sha512-vvMOqVYU3uvdJzg/X6NHewZUEBZhSqND1IEcdahLb6RmvDhsS39iS97VZmEFsjj/UFGoePtYjrrdEgRG9Rm1kQ==
   dependencies:
     "@aws-sdk/middleware-header-default" "3.6.1"
@@ -927,7 +927,7 @@
 
 "@aws-sdk/middleware-header-default@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-header-default/-/middleware-header-default-3.6.1.tgz#a3a108d22cbdd1e1754910625fafb2f2a67fbcfc"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-header-default/-/middleware-header-default-3.6.1.tgz#a3a108d22cbdd1e1754910625fafb2f2a67fbcfc"
   integrity sha512-YD137iIctXVH8Eut0WOBalvvA+uL0jM0UXZ9N2oKrC8kPQPpqjK9lYGFKZQFsl/XlQHAjJi+gCAFrYsBntRWJQ==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -936,7 +936,7 @@
 
 "@aws-sdk/middleware-host-header@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-host-header/-/middleware-host-header-3.6.1.tgz#6e1b4b95c5bfea5a4416fa32f11d8fa2e6edaeff"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-host-header/-/middleware-host-header-3.6.1.tgz#6e1b4b95c5bfea5a4416fa32f11d8fa2e6edaeff"
   integrity sha512-nwq8R2fGBRZQE0Fr/jiOgqfppfiTQCUoD8hyX3qSS7Qc2uqpsDOt2TnnoZl56mpQYkF/344IvMAkp+ew6wR73w==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -945,7 +945,7 @@
 
 "@aws-sdk/middleware-location-constraint@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-location-constraint/-/middleware-location-constraint-3.6.1.tgz#6fc2dd6a42968f011eb060ca564e9f749649eb01"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-location-constraint/-/middleware-location-constraint-3.6.1.tgz#6fc2dd6a42968f011eb060ca564e9f749649eb01"
   integrity sha512-nFisTc0O5D+4I+sRxiiLPasC/I4NDc3s+hgbPPt/b3uAdrujJjhwFBOSaTx8qQvz/xJPAA8pUA/bfWIyeZKi/w==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -953,7 +953,7 @@
 
 "@aws-sdk/middleware-logger@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-logger/-/middleware-logger-3.6.1.tgz#78b3732cf188d5e4df13488db6418f7f98a77d6d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-logger/-/middleware-logger-3.6.1.tgz#78b3732cf188d5e4df13488db6418f7f98a77d6d"
   integrity sha512-zxaSLpwKlja7JvK20UsDTxPqBZUo3rbDA1uv3VWwpxzOrEWSlVZYx/KLuyGWGkx9V71ZEkf6oOWWJIstS0wyQQ==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -961,7 +961,7 @@
 
 "@aws-sdk/middleware-retry@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-retry/-/middleware-retry-3.6.1.tgz#202aadb1a3bf0e1ceabcd8319a5fa308b32db247"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-retry/-/middleware-retry-3.6.1.tgz#202aadb1a3bf0e1ceabcd8319a5fa308b32db247"
   integrity sha512-WHeo4d2jsXxBP+cec2SeLb0btYXwYXuE56WLmNt0RvJYmiBzytUeGJeRa9HuwV574kgigAuHGCeHlPO36G4Y0Q==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -973,7 +973,7 @@
 
 "@aws-sdk/middleware-sdk-s3@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-sdk-s3/-/middleware-sdk-s3-3.6.1.tgz#371f8991ac82432982153c035ab9450d8df14546"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-sdk-s3/-/middleware-sdk-s3-3.6.1.tgz#371f8991ac82432982153c035ab9450d8df14546"
   integrity sha512-HEA9kynNTsOSIIz8p5GEEAH03pnn+SSohwPl80sGqkmI1yl1tzjqgYZRii0e6acJTh4j9655XFzSx36hYPeB2w==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -983,7 +983,7 @@
 
 "@aws-sdk/middleware-serde@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-serde/-/middleware-serde-3.6.1.tgz#734c7d16c2aa9ccc01f6cca5e2f6aa2993b6739d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-serde/-/middleware-serde-3.6.1.tgz#734c7d16c2aa9ccc01f6cca5e2f6aa2993b6739d"
   integrity sha512-EdQCFZRERfP3uDuWcPNuaa2WUR3qL1WFDXafhcx+7ywQxagdYqBUWKFJlLYi6njbkOKXFM+eHBzoXGF0OV3MJA==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -991,7 +991,7 @@
 
 "@aws-sdk/middleware-signing@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-signing/-/middleware-signing-3.6.1.tgz#e70a2f35d85d70e33c9fddfb54b9520f6382db16"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-signing/-/middleware-signing-3.6.1.tgz#e70a2f35d85d70e33c9fddfb54b9520f6382db16"
   integrity sha512-1woKq+1sU3eausdl8BNdAMRZMkSYuy4mxhLsF0/qAUuLwo1eJLLUCOQp477tICawgu4O4q2OAyUHk7wMqYnQCg==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -1001,7 +1001,7 @@
 
 "@aws-sdk/middleware-ssec@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-ssec/-/middleware-ssec-3.6.1.tgz#c7dd80e4c1e06be9050c742af7879619b400f0d1"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-ssec/-/middleware-ssec-3.6.1.tgz#c7dd80e4c1e06be9050c742af7879619b400f0d1"
   integrity sha512-svuH6s91uKUTORt51msiL/ZBjtYSW32c3uVoWxludd/PEf6zO5wCmUEsKoyVwa88L7rrCq+81UBv5A8S5kc3Cw==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1009,14 +1009,14 @@
 
 "@aws-sdk/middleware-stack@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-stack/-/middleware-stack-3.6.1.tgz#d7483201706bb5935a62884e9b60f425f1c6434f"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-stack/-/middleware-stack-3.6.1.tgz#d7483201706bb5935a62884e9b60f425f1c6434f"
   integrity sha512-EPsIxMi8LtCt7YwTFpWGlVGYJc0q4kwFbOssY02qfqdCnyqi2y5wo089dH7OdxUooQ0D7CPsXM1zTTuzvm+9Fw==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/middleware-user-agent@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fmiddleware-user-agent/-/middleware-user-agent-3.6.1.tgz#6845dfb3bc6187897f348c2c87dec833e6a65c99"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fmiddleware-user-agent/-/middleware-user-agent-3.6.1.tgz#6845dfb3bc6187897f348c2c87dec833e6a65c99"
   integrity sha512-YvXvwllNDVvxQ30vIqLsx+P6jjnfFEQUmhlv64n98gOme6h2BqoyQDcC3yHRGctuxRZEsR7W/H1ASTKC+iabbQ==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -1025,7 +1025,7 @@
 
 "@aws-sdk/node-config-provider@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fnode-config-provider/-/node-config-provider-3.6.1.tgz#cb85d06329347fde566f08426f8714b1f65d2fb7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fnode-config-provider/-/node-config-provider-3.6.1.tgz#cb85d06329347fde566f08426f8714b1f65d2fb7"
   integrity sha512-x2Z7lm0ZhHYqMybvkaI5hDKfBkaLaXhTDfgrLl9TmBZ3QHO4fIHgeL82VZ90Paol+OS+jdq2AheLmzbSxv3HrA==
   dependencies:
     "@aws-sdk/property-provider" "3.6.1"
@@ -1035,7 +1035,7 @@
 
 "@aws-sdk/node-http-handler@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fnode-http-handler/-/node-http-handler-3.6.1.tgz#4b65c4dcc0cf46ba44cb6c3bf29c5f817bb8d9a7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fnode-http-handler/-/node-http-handler-3.6.1.tgz#4b65c4dcc0cf46ba44cb6c3bf29c5f817bb8d9a7"
   integrity sha512-6XSaoqbm9ZF6T4UdBCcs/Gn2XclwBotkdjj46AxO+9vRAgZDP+lH/8WwZsvfqJhhRhS0qxWrks98WGJwmaTG8g==
   dependencies:
     "@aws-sdk/abort-controller" "3.6.1"
@@ -1046,7 +1046,7 @@
 
 "@aws-sdk/property-provider@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fproperty-provider/-/property-provider-3.6.1.tgz#d973fc87d199d32c44d947e17f2ee2dd140a9593"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fproperty-provider/-/property-provider-3.6.1.tgz#d973fc87d199d32c44d947e17f2ee2dd140a9593"
   integrity sha512-2gR2DzDySXKFoj9iXLm1TZBVSvFIikEPJsbRmAZx5RBY+tp1IXWqZM6PESjaLdLg/ZtR0QhW2ZcRn0fyq2JfnQ==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1054,7 +1054,7 @@
 
 "@aws-sdk/protocol-http@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fprotocol-http/-/protocol-http-3.6.1.tgz#d3d276846bec19ddb339d06bbc48116d17bbc656"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fprotocol-http/-/protocol-http-3.6.1.tgz#d3d276846bec19ddb339d06bbc48116d17bbc656"
   integrity sha512-WkQz7ncVYTLvCidDfXWouDzqxgSNPZDz3Bql+7VhZeITnzAEcr4hNMyEqMAVYBVugGmkG2W6YiUqNNs1goOcDA==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1062,7 +1062,7 @@
 
 "@aws-sdk/querystring-builder@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fquerystring-builder/-/querystring-builder-3.6.1.tgz#4c769829a3760ef065d0d3801f297a7f0cd324d4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fquerystring-builder/-/querystring-builder-3.6.1.tgz#4c769829a3760ef065d0d3801f297a7f0cd324d4"
   integrity sha512-ESe255Yl6vB1AMNqaGSQow3TBYYnpw0AFjE40q2VyiNrkbaqKmW2EzjeCy3wEmB1IfJDHy3O12ZOMUMOnjFT8g==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1071,7 +1071,7 @@
 
 "@aws-sdk/querystring-parser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fquerystring-parser/-/querystring-parser-3.6.1.tgz#e3fa5a710429c7dd411e802a0b82beb48012cce2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fquerystring-parser/-/querystring-parser-3.6.1.tgz#e3fa5a710429c7dd411e802a0b82beb48012cce2"
   integrity sha512-hh6dhqamKrWWaDSuO2YULci0RGwJWygoy8hpCRxs/FpzzHIcbm6Cl6Jhrn5eKBzOBv+PhCcYwbfad0kIZZovcQ==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1079,7 +1079,7 @@
 
 "@aws-sdk/s3-request-presigner@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fs3-request-presigner/-/s3-request-presigner-3.6.1.tgz#ec83c70171692862a7f7ebbd151242a5af443695"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fs3-request-presigner/-/s3-request-presigner-3.6.1.tgz#ec83c70171692862a7f7ebbd151242a5af443695"
   integrity sha512-OI7UHCKBwuiO/RmHHewBKnL2NYqdilXRmpX67TJ4tTszIrWP2+vpm3lIfrx/BM8nf8nKTzgkO98uFhoJsEhmTg==
   dependencies:
     "@aws-sdk/protocol-http" "3.6.1"
@@ -1092,19 +1092,19 @@
 
 "@aws-sdk/service-error-classification@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fservice-error-classification/-/service-error-classification-3.6.1.tgz#296fe62ac61338341e8a009c9a2dab013a791903"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fservice-error-classification/-/service-error-classification-3.6.1.tgz#296fe62ac61338341e8a009c9a2dab013a791903"
   integrity sha512-kZ7ZhbrN1f+vrSRkTJvXsu7BlOyZgym058nPA745+1RZ1Rtv4Ax8oknf2RvJyj/1qRUi8LBaAREjzQ3C8tmLBA==
 
 "@aws-sdk/shared-ini-file-loader@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fshared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz#2b7182cbb0d632ad7c9712bebffdeee24a6f7eb6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fshared-ini-file-loader/-/shared-ini-file-loader-3.6.1.tgz#2b7182cbb0d632ad7c9712bebffdeee24a6f7eb6"
   integrity sha512-BnLHtsNLOoow6rPV+QVi6jnovU5g1m0YzoUG0BQYZ1ALyVlWVr0VvlUX30gMDfdYoPMp+DHvF8GXdMuGINq6kQ==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/signature-v4@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fsignature-v4/-/signature-v4-3.6.1.tgz#b20a3cf3e891131f83b012651f7d4af2bf240611"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fsignature-v4/-/signature-v4-3.6.1.tgz#b20a3cf3e891131f83b012651f7d4af2bf240611"
   integrity sha512-EAR0qGVL4AgzodZv4t+BSuBfyOXhTNxDxom50IFI1MqidR9vI6avNZKcPHhgXbm7XVcsDGThZKbzQ2q7MZ2NTA==
   dependencies:
     "@aws-sdk/is-array-buffer" "3.6.1"
@@ -1115,7 +1115,7 @@
 
 "@aws-sdk/smithy-client@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fsmithy-client/-/smithy-client-3.6.1.tgz#683fef89802e318922f8529a5433592d71a7ce9d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fsmithy-client/-/smithy-client-3.6.1.tgz#683fef89802e318922f8529a5433592d71a7ce9d"
   integrity sha512-AVpRK4/iUxNeDdAm8UqP0ZgtgJMQeWcagTylijwelhWXyXzHUReY1sgILsWcdWnoy6gq845W7K2VBhBleni8+w==
   dependencies:
     "@aws-sdk/middleware-stack" "3.6.1"
@@ -1124,22 +1124,22 @@
 
 "@aws-sdk/types@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2ftypes/-/types-3.6.1.tgz#00686db69e998b521fcd4a5f81ef0960980f80c4"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2ftypes/-/types-3.6.1.tgz#00686db69e998b521fcd4a5f81ef0960980f80c4"
   integrity sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==
 
 "@aws-sdk/types@^1.0.0-alpha.0":
   version "1.0.0-rc.10"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2ftypes/-/types-1.0.0-rc.10.tgz#729127fbfac5da1a3368ffe6ec2e90acc9ad69c3"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2ftypes/-/types-1.0.0-rc.10.tgz#729127fbfac5da1a3368ffe6ec2e90acc9ad69c3"
   integrity sha512-9gwhYnkTNuYZ+etCtM4T8gjpZ0SWSXbzQxY34UjSS+dt3C/UnbX0J22tMahp/9Z1yCa9pihtXrkD+nO2xn7nVQ==
 
 "@aws-sdk/types@^3.1.0":
   version "3.18.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2ftypes/-/types-3.18.0.tgz#2158f054b83ea1319c47306bf08245fb26edeed0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2ftypes/-/types-3.18.0.tgz#2158f054b83ea1319c47306bf08245fb26edeed0"
   integrity sha512-fyk6HXK1wk83n4fDvsG+ewV+yS4uegepeMNrmLr7iBKjzc/bLckTWk7GKFM5ZaF/9jWyk7o2eKW3C3BltgDrfQ==
 
 "@aws-sdk/url-parser-native@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2furl-parser-native/-/url-parser-native-3.6.1.tgz#a5e787f98aafa777e73007f9490df334ef3389a2"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2furl-parser-native/-/url-parser-native-3.6.1.tgz#a5e787f98aafa777e73007f9490df334ef3389a2"
   integrity sha512-3O+ktsrJoE8YQCho9L41YXO8EWILXrSeES7amUaV3mgIV5w4S3SB/r4RkmylpqRpQF7Ry8LFiAnMqH1wa4WBPA==
   dependencies:
     "@aws-sdk/querystring-parser" "3.6.1"
@@ -1149,7 +1149,7 @@
 
 "@aws-sdk/url-parser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2furl-parser/-/url-parser-3.6.1.tgz#f5d89fb21680469a61cb9fe08a7da3ef887884dd"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2furl-parser/-/url-parser-3.6.1.tgz#f5d89fb21680469a61cb9fe08a7da3ef887884dd"
   integrity sha512-pWFIePDx0PMCleQRsQDWoDl17YiijOLj0ZobN39rQt+wv5PhLSZDz9PgJsqS48nZ6hqsKgipRcjiBMhn5NtFcQ==
   dependencies:
     "@aws-sdk/querystring-parser" "3.6.1"
@@ -1158,21 +1158,21 @@
 
 "@aws-sdk/util-arn-parser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-arn-parser/-/util-arn-parser-3.6.1.tgz#aa60b1bfa752ad3fa331f22fea4f703b741d1d6d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-arn-parser/-/util-arn-parser-3.6.1.tgz#aa60b1bfa752ad3fa331f22fea4f703b741d1d6d"
   integrity sha512-NFdYeuhaSrgnBG6Pt3zHNU7QwvhHq6sKUTWZShUayLMJYYbQr6IjmYVlPST4c84b+lyDoK68y/Zga621VfIdBg==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-base64-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-base64-browser/-/util-base64-browser-3.6.1.tgz#eddea1311b41037fc3fddd889d3e0a9882363215"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-base64-browser/-/util-base64-browser-3.6.1.tgz#eddea1311b41037fc3fddd889d3e0a9882363215"
   integrity sha512-+DHAIgt0AFARDVC7J0Z9FkSmJhBMlkYdOPeAAgO0WaQoKj7rtsLQJ7P3v3aS1paKN5/sk5xNY7ziVB6uHtOvHA==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-base64-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-base64-node/-/util-base64-node-3.6.1.tgz#a79c233861e50d3a30728c72b736afdee07d4009"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-base64-node/-/util-base64-node-3.6.1.tgz#a79c233861e50d3a30728c72b736afdee07d4009"
   integrity sha512-oiqzpsvtTSS92+cL3ykhGd7t3qBJKeHvrgOwUyEf1wFWHQ2DPJR+dIMy5rMFRXWLKCl3w7IddY2rJCkLYMjaqQ==
   dependencies:
     "@aws-sdk/util-buffer-from" "3.6.1"
@@ -1180,21 +1180,21 @@
 
 "@aws-sdk/util-body-length-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-body-length-browser/-/util-body-length-browser-3.6.1.tgz#2e8088f2d9a5a8258b4f56079a8890f538c2797e"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-body-length-browser/-/util-body-length-browser-3.6.1.tgz#2e8088f2d9a5a8258b4f56079a8890f538c2797e"
   integrity sha512-IdWwE3rm/CFDk2F+IwTZOFTnnNW5SB8y1lWiQ54cfc7y03hO6jmXNnpZGZ5goHhT+vf1oheNQt1J47m0pM/Irw==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-body-length-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-body-length-node/-/util-body-length-node-3.6.1.tgz#6e4f2eae46c5a7b0417a12ca7f4b54c390d4cacd"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-body-length-node/-/util-body-length-node-3.6.1.tgz#6e4f2eae46c5a7b0417a12ca7f4b54c390d4cacd"
   integrity sha512-CUG3gc18bSOsqViQhB3M4AlLpAWV47RE6yWJ6rLD0J6/rSuzbwbjzxM39q0YTAVuSo/ivdbij+G9c3QCirC+QQ==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-buffer-from@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-buffer-from/-/util-buffer-from-3.6.1.tgz#24184ce74512f764d84002201b7f5101565e26f9"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-buffer-from/-/util-buffer-from-3.6.1.tgz#24184ce74512f764d84002201b7f5101565e26f9"
   integrity sha512-OGUh2B5NY4h7iRabqeZ+EgsrzE1LUmNFzMyhoZv0tO4NExyfQjxIYXLQQvydeOq9DJUbCw+yrRZrj8vXNDQG+g==
   dependencies:
     "@aws-sdk/is-array-buffer" "3.6.1"
@@ -1202,7 +1202,7 @@
 
 "@aws-sdk/util-create-request@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-create-request/-/util-create-request-3.6.1.tgz#ecc4364551c7b3d0d9834ca3f56528fb8b083838"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-create-request/-/util-create-request-3.6.1.tgz#ecc4364551c7b3d0d9834ca3f56528fb8b083838"
   integrity sha512-jR1U8WpwXl+xZ9ThS42Jr5MXuegQ7QioHsZjQn3V5pbm8CXTkBF0B2BcULQu/2G1XtHOJb8qUZQlk/REoaORfQ==
   dependencies:
     "@aws-sdk/middleware-stack" "3.6.1"
@@ -1212,7 +1212,7 @@
 
 "@aws-sdk/util-format-url@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-format-url/-/util-format-url-3.6.1.tgz#a011444aed0c47698d65095bcce95d7b4716324b"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-format-url/-/util-format-url-3.6.1.tgz#a011444aed0c47698d65095bcce95d7b4716324b"
   integrity sha512-FvhcXcqLyJ0j0WdlmGs7PtjCCv8NaY4zBuXYO2iwAmqoy2SIZXQL63uAvmilqWj25q47ASAsUwSFLReCCfMklQ==
   dependencies:
     "@aws-sdk/querystring-builder" "3.6.1"
@@ -1221,28 +1221,28 @@
 
 "@aws-sdk/util-hex-encoding@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-hex-encoding/-/util-hex-encoding-3.6.1.tgz#84954fcc47b74ffbd2911ba5113e93bd9b1c6510"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-hex-encoding/-/util-hex-encoding-3.6.1.tgz#84954fcc47b74ffbd2911ba5113e93bd9b1c6510"
   integrity sha512-pzsGOHtU2eGca4NJgFg94lLaeXDOg8pcS9sVt4f9LmtUGbrqRveeyBv0XlkHeZW2n0IZBssPHipVYQFlk7iaRA==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-locate-window@^3.0.0":
   version "3.18.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-locate-window/-/util-locate-window-3.18.0.tgz#47bb20b6f9fcff45ec948e125a4e8f892f029d80"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-locate-window/-/util-locate-window-3.18.0.tgz#47bb20b6f9fcff45ec948e125a4e8f892f029d80"
   integrity sha512-Lj2O9KaXCn+gPW23l3ydcSWe4HK0jH6teeSymbaFTwTjKtr4oLfDDKAOFoG5YyppQstEPqsL/RidVey4kOFfcg==
   dependencies:
     tslib "^2.0.0"
 
 "@aws-sdk/util-uri-escape@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-uri-escape/-/util-uri-escape-3.6.1.tgz#433e87458bb510d0e457a86c0acf12b046a5068c"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-uri-escape/-/util-uri-escape-3.6.1.tgz#433e87458bb510d0e457a86c0acf12b046a5068c"
   integrity sha512-tgABiT71r0ScRJZ1pMX0xO0QPMMiISCtumph50IU5VDyZWYgeIxqkMhIcrL1lX0QbNCMgX0n6rZxGrrbjDNavA==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-user-agent-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz#11b9cc8743392761adb304460f4b54ec8acc2ee6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-user-agent-browser/-/util-user-agent-browser-3.6.1.tgz#11b9cc8743392761adb304460f4b54ec8acc2ee6"
   integrity sha512-KhJ4VED4QpuBVPXoTjb5LqspX1xHWJTuL8hbPrKfxj+cAaRRW2CNEe7PPy2CfuHtPzP3dU3urtGTachbwNb0jg==
   dependencies:
     "@aws-sdk/types" "3.6.1"
@@ -1251,7 +1251,7 @@
 
 "@aws-sdk/util-user-agent-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-user-agent-node/-/util-user-agent-node-3.6.1.tgz#98384095fa67d098ae7dd26f3ccaad028e8aebb6"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-user-agent-node/-/util-user-agent-node-3.6.1.tgz#98384095fa67d098ae7dd26f3ccaad028e8aebb6"
   integrity sha512-PWwL5EDRwhkXX40m5jjgttlBmLA7vDhHBen1Jcle0RPIDFRVPSE7GgvLF3y4r3SNH0WD6hxqadT50bHQynXW6w==
   dependencies:
     "@aws-sdk/node-config-provider" "3.6.1"
@@ -1260,28 +1260,28 @@
 
 "@aws-sdk/util-utf8-browser@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.6.1.tgz#97a8770cae9d29218adc0f32c7798350261377c7"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.6.1.tgz#97a8770cae9d29218adc0f32c7798350261377c7"
   integrity sha512-gZPySY6JU5gswnw3nGOEHl3tYE7vPKvtXGYoS2NRabfDKRejFvu+4/nNW6SSpoOxk6LSXsrWB39NO51k+G4PVA==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-utf8-browser@^1.0.0-alpha.0":
   version "1.0.0-rc.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz#bf1f1cfed8c024f43a7c43b643fdf2b4523b5973"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-1.0.0-rc.8.tgz#bf1f1cfed8c024f43a7c43b643fdf2b4523b5973"
   integrity sha512-clncPMJ23rxCIkZ9LoUC8SowwZGxWyN2TwRb0XvW/Cv9EavkRgRCOrCpneGyC326lqtMKx36onnpaSRHxErUYw==
   dependencies:
     tslib "^1.8.0"
 
 "@aws-sdk/util-utf8-browser@^3.0.0":
   version "3.18.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.18.0.tgz#d7d68290a323e4f9eb4f1d3f6add618c17e01a36"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-utf8-browser/-/util-utf8-browser-3.18.0.tgz#d7d68290a323e4f9eb4f1d3f6add618c17e01a36"
   integrity sha512-JwcdTb6AAMtnlt2Sg0I18DBK1sWlsfDR/23CkDQ52niXvCSRdHeNkh5b7SdEPVUKI76hyce9nEshzI1OasTv7w==
   dependencies:
     tslib "^2.0.0"
 
 "@aws-sdk/util-utf8-node@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-utf8-node/-/util-utf8-node-3.6.1.tgz#18534c2069b61f5739ee4cdc70060c9f4b4c4c4f"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-utf8-node/-/util-utf8-node-3.6.1.tgz#18534c2069b61f5739ee4cdc70060c9f4b4c4c4f"
   integrity sha512-4s0vYfMUn74XLn13rUUhNsmuPMh0j1d4rF58wXtjlVUU78THxonnN8mbCLC48fI3fKDHTmDDkeEqy7+IWP9VyA==
   dependencies:
     "@aws-sdk/util-buffer-from" "3.6.1"
@@ -1289,7 +1289,7 @@
 
 "@aws-sdk/util-waiter@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2futil-waiter/-/util-waiter-3.6.1.tgz#5c66c2da33ff98468726fefddc2ca7ac3352c17d"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2futil-waiter/-/util-waiter-3.6.1.tgz#5c66c2da33ff98468726fefddc2ca7ac3352c17d"
   integrity sha512-CQMRteoxW1XZSzPBVrTsOTnfzsEGs8N/xZ8BuBnXLBjoIQmRKVxIH9lgphm1ohCtVHoSWf28XH/KoOPFULQ4Tg==
   dependencies:
     "@aws-sdk/abort-controller" "3.6.1"
@@ -1298,7 +1298,7 @@
 
 "@aws-sdk/xml-builder@3.6.1":
   version "3.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@aws-sdk%2fxml-builder/-/xml-builder-3.6.1.tgz#d85d7db5e8e30ba74de93ddf0cf6197e6e4b15ea"
+  resolved "https://registry.yarnpkg.com/@aws-sdk%2fxml-builder/-/xml-builder-3.6.1.tgz#d85d7db5e8e30ba74de93ddf0cf6197e6e4b15ea"
   integrity sha512-+HOCH4a0XO+I09okd0xdVP5Q5c9ZsEsDvnogiOcBQxoMivWhPUCo9pjXP3buCvVKP2oDHXQplBKSjGHvGaKFdg==
   dependencies:
     tslib "^1.8.0"
@@ -1319,14 +1319,14 @@
 
 "@babel/code-frame@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fcode-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  resolved "https://registry.yarnpkg.com/@babel%2fcode-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
   dependencies:
     "@babel/highlight" "^7.16.7"
 
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.16.8", "@babel/compat-data@^7.17.0", "@babel/compat-data@^7.17.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fcompat-data/-/compat-data-7.17.7.tgz#078d8b833fbbcc95286613be8c716cef2b519fa2"
+  resolved "https://registry.yarnpkg.com/@babel%2fcompat-data/-/compat-data-7.17.7.tgz#078d8b833fbbcc95286613be8c716cef2b519fa2"
   integrity sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==
 
 "@babel/core@>=7.9.0":
@@ -1352,7 +1352,7 @@
 
 "@babel/core@^7.16.0":
   version "7.17.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fcore/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
+  resolved "https://registry.yarnpkg.com/@babel%2fcore/-/core-7.17.8.tgz#3dac27c190ebc3a4381110d46c80e77efe172e1a"
   integrity sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
@@ -1382,7 +1382,7 @@
 
 "@babel/generator@^7.17.3", "@babel/generator@^7.17.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fgenerator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
+  resolved "https://registry.yarnpkg.com/@babel%2fgenerator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
   integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
   dependencies:
     "@babel/types" "^7.17.0"
@@ -1398,14 +1398,14 @@
 
 "@babel/helper-annotate-as-pure@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
   integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
   dependencies:
     "@babel/types" "^7.16.7"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz#38d138561ea207f0f69eb1626a418e4f7e6a580b"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz#38d138561ea207f0f69eb1626a418e4f7e6a580b"
   integrity sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==
   dependencies:
     "@babel/helper-explode-assignable-expression" "^7.16.7"
@@ -1413,7 +1413,7 @@
 
 "@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.7", "@babel/helper-compilation-targets@^7.17.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz#a3c2924f5e5f0379b356d4cfb313d1414dc30e46"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz#a3c2924f5e5f0379b356d4cfb313d1414dc30e46"
   integrity sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==
   dependencies:
     "@babel/compat-data" "^7.17.7"
@@ -1423,7 +1423,7 @@
 
 "@babel/helper-create-class-features-plugin@^7.16.10", "@babel/helper-create-class-features-plugin@^7.16.7", "@babel/helper-create-class-features-plugin@^7.17.6":
   version "7.17.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
   integrity sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -1444,7 +1444,7 @@
 
 "@babel/helper-create-regexp-features-plugin@^7.16.7":
   version "7.17.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz#1dcc7d40ba0c6b6b25618997c5dbfd310f186fe1"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz#1dcc7d40ba0c6b6b25618997c5dbfd310f186fe1"
   integrity sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -1452,7 +1452,7 @@
 
 "@babel/helper-define-polyfill-provider@^0.3.1":
   version "0.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz#52411b445bdb2e676869e5a74960d2d3826d2665"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz#52411b445bdb2e676869e5a74960d2d3826d2665"
   integrity sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==
   dependencies:
     "@babel/helper-compilation-targets" "^7.13.0"
@@ -1466,14 +1466,14 @@
 
 "@babel/helper-environment-visitor@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
   integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
   dependencies:
     "@babel/types" "^7.16.7"
 
 "@babel/helper-explode-assignable-expression@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz#12a6d8522fdd834f194e868af6354e8650242b7a"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz#12a6d8522fdd834f194e868af6354e8650242b7a"
   integrity sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==
   dependencies:
     "@babel/types" "^7.16.7"
@@ -1489,7 +1489,7 @@
 
 "@babel/helper-function-name@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
   integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
   dependencies:
     "@babel/helper-get-function-arity" "^7.16.7"
@@ -1505,14 +1505,14 @@
 
 "@babel/helper-get-function-arity@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
   integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
   dependencies:
     "@babel/types" "^7.16.7"
 
 "@babel/helper-hoist-variables@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
   integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
   dependencies:
     "@babel/types" "^7.16.7"
@@ -1526,7 +1526,7 @@
 
 "@babel/helper-member-expression-to-functions@^7.16.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz#a34013b57d8542a8c4ff8ba3f747c02452a4d8c4"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz#a34013b57d8542a8c4ff8ba3f747c02452a4d8c4"
   integrity sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==
   dependencies:
     "@babel/types" "^7.17.0"
@@ -1540,7 +1540,7 @@
 
 "@babel/helper-module-imports@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
   integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
   dependencies:
     "@babel/types" "^7.16.7"
@@ -1562,7 +1562,7 @@
 
 "@babel/helper-module-transforms@^7.16.7", "@babel/helper-module-transforms@^7.17.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-module-transforms/-/helper-module-transforms-7.17.7.tgz#3943c7f777139e7954a5355c815263741a9c1cbd"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-module-transforms/-/helper-module-transforms-7.17.7.tgz#3943c7f777139e7954a5355c815263741a9c1cbd"
   integrity sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==
   dependencies:
     "@babel/helper-environment-visitor" "^7.16.7"
@@ -1583,7 +1583,7 @@
 
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
   integrity sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==
   dependencies:
     "@babel/types" "^7.16.7"
@@ -1600,12 +1600,12 @@
 
 "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
   integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-remap-async-to-generator@^7.16.8":
   version "7.16.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz#29ffaade68a367e2ed09c90901986918d25e57e3"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz#29ffaade68a367e2ed09c90901986918d25e57e3"
   integrity sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -1624,7 +1624,7 @@
 
 "@babel/helper-replace-supers@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1"
   integrity sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==
   dependencies:
     "@babel/helper-environment-visitor" "^7.16.7"
@@ -1642,14 +1642,14 @@
 
 "@babel/helper-simple-access@^7.17.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-simple-access/-/helper-simple-access-7.17.7.tgz#aaa473de92b7987c6dfa7ce9a7d9674724823367"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-simple-access/-/helper-simple-access-7.17.7.tgz#aaa473de92b7987c6dfa7ce9a7d9674724823367"
   integrity sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==
   dependencies:
     "@babel/types" "^7.17.0"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz#0ee3388070147c3ae051e487eca3ebb0e2e8bb09"
   integrity sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==
   dependencies:
     "@babel/types" "^7.16.0"
@@ -1663,7 +1663,7 @@
 
 "@babel/helper-split-export-declaration@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
   integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
   dependencies:
     "@babel/types" "^7.16.7"
@@ -1675,17 +1675,17 @@
 
 "@babel/helper-validator-identifier@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
   integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-wrap-function@^7.16.8":
   version "7.16.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelper-wrap-function/-/helper-wrap-function-7.16.8.tgz#58afda087c4cd235de92f7ceedebca2c41274200"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelper-wrap-function/-/helper-wrap-function-7.16.8.tgz#58afda087c4cd235de92f7ceedebca2c41274200"
   integrity sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==
   dependencies:
     "@babel/helper-function-name" "^7.16.7"
@@ -1704,7 +1704,7 @@
 
 "@babel/helpers@^7.17.8":
   version "7.17.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhelpers/-/helpers-7.17.8.tgz#288450be8c6ac7e4e44df37bcc53d345e07bc106"
+  resolved "https://registry.yarnpkg.com/@babel%2fhelpers/-/helpers-7.17.8.tgz#288450be8c6ac7e4e44df37bcc53d345e07bc106"
   integrity sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==
   dependencies:
     "@babel/template" "^7.16.7"
@@ -1722,7 +1722,7 @@
 
 "@babel/highlight@^7.16.7":
   version "7.16.10"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fhighlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
+  resolved "https://registry.yarnpkg.com/@babel%2fhighlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
   integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
@@ -1736,19 +1736,19 @@
 
 "@babel/parser@^7.16.7", "@babel/parser@^7.17.3", "@babel/parser@^7.17.8":
   version "7.17.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fparser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
+  resolved "https://registry.yarnpkg.com/@babel%2fparser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
   integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz#4eda6d6c2a0aa79c70fa7b6da67763dfe2141050"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz#4eda6d6c2a0aa79c70fa7b6da67763dfe2141050"
   integrity sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz#cc001234dfc139ac45f6bcf801866198c8c72ff9"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz#cc001234dfc139ac45f6bcf801866198c8c72ff9"
   integrity sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1757,7 +1757,7 @@
 
 "@babel/plugin-proposal-async-generator-functions@^7.16.8":
   version "7.16.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz#3bdd1ebbe620804ea9416706cd67d60787504bc8"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz#3bdd1ebbe620804ea9416706cd67d60787504bc8"
   integrity sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1766,7 +1766,7 @@
 
 "@babel/plugin-proposal-class-properties@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz#925cad7b3b1a2fcea7e59ecc8eb5954f961f91b0"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz#925cad7b3b1a2fcea7e59ecc8eb5954f961f91b0"
   integrity sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.16.7"
@@ -1774,7 +1774,7 @@
 
 "@babel/plugin-proposal-class-static-block@^7.16.7":
   version "7.17.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz#164e8fd25f0d80fa48c5a4d1438a6629325ad83c"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz#164e8fd25f0d80fa48c5a4d1438a6629325ad83c"
   integrity sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.17.6"
@@ -1783,7 +1783,7 @@
 
 "@babel/plugin-proposal-dynamic-import@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz#c19c897eaa46b27634a00fee9fb7d829158704b2"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz#c19c897eaa46b27634a00fee9fb7d829158704b2"
   integrity sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1791,7 +1791,7 @@
 
 "@babel/plugin-proposal-export-namespace-from@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz#09de09df18445a5786a305681423ae63507a6163"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz#09de09df18445a5786a305681423ae63507a6163"
   integrity sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1799,7 +1799,7 @@
 
 "@babel/plugin-proposal-json-strings@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz#9732cb1d17d9a2626a08c5be25186c195b6fa6e8"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz#9732cb1d17d9a2626a08c5be25186c195b6fa6e8"
   integrity sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1807,7 +1807,7 @@
 
 "@babel/plugin-proposal-logical-assignment-operators@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz#be23c0ba74deec1922e639832904be0bea73cdea"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz#be23c0ba74deec1922e639832904be0bea73cdea"
   integrity sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1815,7 +1815,7 @@
 
 "@babel/plugin-proposal-nullish-coalescing-operator@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz#141fc20b6857e59459d430c850a0011e36561d99"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz#141fc20b6857e59459d430c850a0011e36561d99"
   integrity sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1823,7 +1823,7 @@
 
 "@babel/plugin-proposal-numeric-separator@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz#d6b69f4af63fb38b6ca2558442a7fb191236eba9"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz#d6b69f4af63fb38b6ca2558442a7fb191236eba9"
   integrity sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1831,7 +1831,7 @@
 
 "@babel/plugin-proposal-object-rest-spread@^7.16.7":
   version "7.17.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz#d9eb649a54628a51701aef7e0ea3d17e2b9dd390"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz#d9eb649a54628a51701aef7e0ea3d17e2b9dd390"
   integrity sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==
   dependencies:
     "@babel/compat-data" "^7.17.0"
@@ -1842,7 +1842,7 @@
 
 "@babel/plugin-proposal-optional-catch-binding@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz#c623a430674ffc4ab732fd0a0ae7722b67cb74cf"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz#c623a430674ffc4ab732fd0a0ae7722b67cb74cf"
   integrity sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1850,7 +1850,7 @@
 
 "@babel/plugin-proposal-optional-chaining@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz#7cd629564724816c0e8a969535551f943c64c39a"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz#7cd629564724816c0e8a969535551f943c64c39a"
   integrity sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1859,7 +1859,7 @@
 
 "@babel/plugin-proposal-private-methods@^7.16.11":
   version "7.16.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz#e8df108288555ff259f4527dbe84813aac3a1c50"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz#e8df108288555ff259f4527dbe84813aac3a1c50"
   integrity sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.16.10"
@@ -1867,7 +1867,7 @@
 
 "@babel/plugin-proposal-private-property-in-object@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz#b0b8cef543c2c3d57e59e2c611994861d46a3fce"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz#b0b8cef543c2c3d57e59e2c611994861d46a3fce"
   integrity sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -1877,7 +1877,7 @@
 
 "@babel/plugin-proposal-unicode-property-regex@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz#635d18eb10c6214210ffc5ff4932552de08188a2"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz#635d18eb10c6214210ffc5ff4932552de08188a2"
   integrity sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
@@ -1893,7 +1893,7 @@
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
   integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
@@ -1907,14 +1907,14 @@
 
 "@babel/plugin-syntax-class-static-block@^7.14.5":
   version "7.14.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz#195df89b146b4b78b3bf897fd7a257c84659d406"
   integrity sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-dynamic-import@^7.8.3":
   version "7.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
   integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
@@ -1928,14 +1928,14 @@
 
 "@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-jsx@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
   integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -1949,7 +1949,7 @@
 
 "@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
   version "7.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
@@ -1963,14 +1963,14 @@
 
 "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
@@ -1984,28 +1984,28 @@
 
 "@babel/plugin-syntax-private-property-in-object@^7.14.5":
   version "7.14.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz#0dc6671ec0ea22b6e94a1114f857970cd39de1ad"
   integrity sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-syntax-top-level-await@^7.14.5":
   version "7.14.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz#c1cfdadc35a646240001f06138247b741c34d94c"
   integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-arrow-functions@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz#44125e653d94b98db76369de9c396dc14bef4154"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz#44125e653d94b98db76369de9c396dc14bef4154"
   integrity sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-async-to-generator@^7.16.8":
   version "7.16.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz#b83dff4b970cf41f1b819f8b49cc0cfbaa53a808"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz#b83dff4b970cf41f1b819f8b49cc0cfbaa53a808"
   integrity sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==
   dependencies:
     "@babel/helper-module-imports" "^7.16.7"
@@ -2014,21 +2014,21 @@
 
 "@babel/plugin-transform-block-scoped-functions@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz#4d0d57d9632ef6062cdf354bb717102ee042a620"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz#4d0d57d9632ef6062cdf354bb717102ee042a620"
   integrity sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-block-scoping@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz#f50664ab99ddeaee5bc681b8f3a6ea9d72ab4f87"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz#f50664ab99ddeaee5bc681b8f3a6ea9d72ab4f87"
   integrity sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-classes@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz#8f4b9562850cd973de3b498f1218796eb181ce00"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz#8f4b9562850cd973de3b498f1218796eb181ce00"
   integrity sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -2042,21 +2042,21 @@
 
 "@babel/plugin-transform-computed-properties@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz#66dee12e46f61d2aae7a73710f591eb3df616470"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz#66dee12e46f61d2aae7a73710f591eb3df616470"
   integrity sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-destructuring@^7.16.7":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz#49dc2675a7afa9a5e4c6bdee636061136c3408d1"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz#49dc2675a7afa9a5e4c6bdee636061136c3408d1"
   integrity sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-dotall-regex@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz#6b2d67686fab15fb6a7fd4bd895d5982cfc81241"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz#6b2d67686fab15fb6a7fd4bd895d5982cfc81241"
   integrity sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
@@ -2072,14 +2072,14 @@
 
 "@babel/plugin-transform-duplicate-keys@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz#2207e9ca8f82a0d36a5a67b6536e7ef8b08823c9"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz#2207e9ca8f82a0d36a5a67b6536e7ef8b08823c9"
   integrity sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-exponentiation-operator@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz#efa9862ef97e9e9e5f653f6ddc7b665e8536fe9b"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz#efa9862ef97e9e9e5f653f6ddc7b665e8536fe9b"
   integrity sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.16.7"
@@ -2087,14 +2087,14 @@
 
 "@babel/plugin-transform-for-of@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz#649d639d4617dff502a9a158c479b3b556728d8c"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz#649d639d4617dff502a9a158c479b3b556728d8c"
   integrity sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-function-name@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz#5ab34375c64d61d083d7d2f05c38d90b97ec65cf"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz#5ab34375c64d61d083d7d2f05c38d90b97ec65cf"
   integrity sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==
   dependencies:
     "@babel/helper-compilation-targets" "^7.16.7"
@@ -2103,21 +2103,21 @@
 
 "@babel/plugin-transform-literals@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz#254c9618c5ff749e87cb0c0cef1a0a050c0bdab1"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz#254c9618c5ff749e87cb0c0cef1a0a050c0bdab1"
   integrity sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-member-expression-literals@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz#6e5dcf906ef8a098e630149d14c867dd28f92384"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz#6e5dcf906ef8a098e630149d14c867dd28f92384"
   integrity sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-modules-amd@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz#b28d323016a7daaae8609781d1f8c9da42b13186"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz#b28d323016a7daaae8609781d1f8c9da42b13186"
   integrity sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==
   dependencies:
     "@babel/helper-module-transforms" "^7.16.7"
@@ -2126,7 +2126,7 @@
 
 "@babel/plugin-transform-modules-commonjs@^7.16.8":
   version "7.17.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz#d86b217c8e45bb5f2dbc11eefc8eab62cf980d19"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.7.tgz#d86b217c8e45bb5f2dbc11eefc8eab62cf980d19"
   integrity sha512-ITPmR2V7MqioMJyrxUo2onHNC3e+MvfFiFIR0RP21d3PtlVb6sfzoxNKiphSZUOM9hEIdzCcZe83ieX3yoqjUA==
   dependencies:
     "@babel/helper-module-transforms" "^7.17.7"
@@ -2136,7 +2136,7 @@
 
 "@babel/plugin-transform-modules-systemjs@^7.16.7":
   version "7.17.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz#81fd834024fae14ea78fbe34168b042f38703859"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.8.tgz#81fd834024fae14ea78fbe34168b042f38703859"
   integrity sha512-39reIkMTUVagzgA5x88zDYXPCMT6lcaRKs1+S9K6NKBPErbgO/w/kP8GlNQTC87b412ZTlmNgr3k2JrWgHH+Bw==
   dependencies:
     "@babel/helper-hoist-variables" "^7.16.7"
@@ -2147,7 +2147,7 @@
 
 "@babel/plugin-transform-modules-umd@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz#23dad479fa585283dbd22215bff12719171e7618"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz#23dad479fa585283dbd22215bff12719171e7618"
   integrity sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==
   dependencies:
     "@babel/helper-module-transforms" "^7.16.7"
@@ -2155,21 +2155,21 @@
 
 "@babel/plugin-transform-named-capturing-groups-regex@^7.16.8":
   version "7.16.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz#7f860e0e40d844a02c9dcf9d84965e7dfd666252"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz#7f860e0e40d844a02c9dcf9d84965e7dfd666252"
   integrity sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
 
 "@babel/plugin-transform-new-target@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz#9967d89a5c243818e0800fdad89db22c5f514244"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz#9967d89a5c243818e0800fdad89db22c5f514244"
   integrity sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-object-super@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz#ac359cf8d32cf4354d27a46867999490b6c32a94"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz#ac359cf8d32cf4354d27a46867999490b6c32a94"
   integrity sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -2177,35 +2177,35 @@
 
 "@babel/plugin-transform-parameters@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz#a1721f55b99b736511cb7e0152f61f17688f331f"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz#a1721f55b99b736511cb7e0152f61f17688f331f"
   integrity sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-property-literals@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz#2dadac85155436f22c696c4827730e0fe1057a55"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz#2dadac85155436f22c696c4827730e0fe1057a55"
   integrity sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-react-display-name@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz#7b6d40d232f4c0f550ea348593db3b21e2404340"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz#7b6d40d232f4c0f550ea348593db3b21e2404340"
   integrity sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-react-jsx-development@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz#43a00724a3ed2557ed3f276a01a929e6686ac7b8"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz#43a00724a3ed2557ed3f276a01a929e6686ac7b8"
   integrity sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==
   dependencies:
     "@babel/plugin-transform-react-jsx" "^7.16.7"
 
 "@babel/plugin-transform-react-jsx@^7.16.7":
   version "7.17.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz#eac1565da176ccb1a715dae0b4609858808008c1"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz#eac1565da176ccb1a715dae0b4609858808008c1"
   integrity sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -2216,7 +2216,7 @@
 
 "@babel/plugin-transform-react-pure-annotations@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz#232bfd2f12eb551d6d7d01d13fe3f86b45eb9c67"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz#232bfd2f12eb551d6d7d01d13fe3f86b45eb9c67"
   integrity sha512-hs71ToC97k3QWxswh2ElzMFABXHvGiJ01IB1TbYQDGeWRKWz/MPUTh5jGExdHvosYKpnJW5Pm3S4+TA3FyX+GA==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.16.7"
@@ -2224,28 +2224,28 @@
 
 "@babel/plugin-transform-regenerator@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz#9e7576dc476cb89ccc5096fff7af659243b4adeb"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz#9e7576dc476cb89ccc5096fff7af659243b4adeb"
   integrity sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==
   dependencies:
     regenerator-transform "^0.14.2"
 
 "@babel/plugin-transform-reserved-words@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz#1d798e078f7c5958eec952059c460b220a63f586"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz#1d798e078f7c5958eec952059c460b220a63f586"
   integrity sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-shorthand-properties@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz#e8549ae4afcf8382f711794c0c7b6b934c5fbd2a"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz#e8549ae4afcf8382f711794c0c7b6b934c5fbd2a"
   integrity sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-spread@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz#a303e2122f9f12e0105daeedd0f30fb197d8ff44"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz#a303e2122f9f12e0105daeedd0f30fb197d8ff44"
   integrity sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -2253,35 +2253,35 @@
 
 "@babel/plugin-transform-sticky-regex@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz#c84741d4f4a38072b9a1e2e3fd56d359552e8660"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz#c84741d4f4a38072b9a1e2e3fd56d359552e8660"
   integrity sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-template-literals@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz#f3d1c45d28967c8e80f53666fc9c3e50618217ab"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz#f3d1c45d28967c8e80f53666fc9c3e50618217ab"
   integrity sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-typeof-symbol@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz#9cdbe622582c21368bd482b660ba87d5545d4f7e"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz#9cdbe622582c21368bd482b660ba87d5545d4f7e"
   integrity sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-unicode-escapes@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz#da8717de7b3287a2c6d659750c964f302b31ece3"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz#da8717de7b3287a2c6d659750c964f302b31ece3"
   integrity sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-unicode-regex@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fplugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz#0f7aa4a501198976e25e82702574c34cfebe9ef2"
+  resolved "https://registry.yarnpkg.com/@babel%2fplugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz#0f7aa4a501198976e25e82702574c34cfebe9ef2"
   integrity sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==
   dependencies:
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
@@ -2297,7 +2297,7 @@
 
 "@babel/preset-env@^7.16.0":
   version "7.16.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fpreset-env/-/preset-env-7.16.11.tgz#5dd88fd885fae36f88fd7c8342475c9f0abe2982"
+  resolved "https://registry.yarnpkg.com/@babel%2fpreset-env/-/preset-env-7.16.11.tgz#5dd88fd885fae36f88fd7c8342475c9f0abe2982"
   integrity sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==
   dependencies:
     "@babel/compat-data" "^7.16.8"
@@ -2377,7 +2377,7 @@
 
 "@babel/preset-modules@^0.1.5":
   version "0.1.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fpreset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
+  resolved "https://registry.yarnpkg.com/@babel%2fpreset-modules/-/preset-modules-0.1.5.tgz#ef939d6e7f268827e1841638dc6ff95515e115d9"
   integrity sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -2388,7 +2388,7 @@
 
 "@babel/preset-react@^7.16.0":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fpreset-react/-/preset-react-7.16.7.tgz#4c18150491edc69c183ff818f9f2aecbe5d93852"
+  resolved "https://registry.yarnpkg.com/@babel%2fpreset-react/-/preset-react-7.16.7.tgz#4c18150491edc69c183ff818f9f2aecbe5d93852"
   integrity sha512-fWpyI8UM/HE6DfPBzD8LnhQ/OcH8AgTaqcqP2nGOXEUV+VKBR5JRN9hCk9ai+zQQ57vtm9oWeXguBCPNUjytgA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.16.7"
@@ -2407,14 +2407,14 @@
 
 "@babel/runtime@^7.12.0", "@babel/runtime@^7.7.2":
   version "7.13.17"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fruntime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  resolved "https://registry.yarnpkg.com/@babel%2fruntime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
   integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.17.8":
   version "7.20.13"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2fruntime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  resolved "https://registry.yarnpkg.com/@babel%2fruntime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
   integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
   dependencies:
     regenerator-runtime "^0.13.11"
@@ -2430,7 +2430,7 @@
 
 "@babel/template@^7.16.7":
   version "7.16.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2ftemplate/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  resolved "https://registry.yarnpkg.com/@babel%2ftemplate/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
   integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
   dependencies:
     "@babel/code-frame" "^7.16.7"
@@ -2454,7 +2454,7 @@
 
 "@babel/traverse@^7.13.0", "@babel/traverse@^7.16.7", "@babel/traverse@^7.16.8", "@babel/traverse@^7.17.3":
   version "7.17.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2ftraverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
+  resolved "https://registry.yarnpkg.com/@babel%2ftraverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
   integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
   dependencies:
     "@babel/code-frame" "^7.16.7"
@@ -2479,7 +2479,7 @@
 
 "@babel/types@^7.16.0", "@babel/types@^7.16.7", "@babel/types@^7.16.8", "@babel/types@^7.17.0":
   version "7.17.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@babel%2ftypes/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  resolved "https://registry.yarnpkg.com/@babel%2ftypes/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
   integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
@@ -2499,7 +2499,7 @@
 
 "@citation-js/cli@0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fcli/-/cli-0.5.0.tgz#4d6d3cc96c154ef7c089c831afa29a41328f647e"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fcli/-/cli-0.5.0.tgz#4d6d3cc96c154ef7c089c831afa29a41328f647e"
   integrity sha512-gTUuJDMuGeGZxG6cqaiYjjGgRI0JehvyvYfJEd+Yf9fqI6tqCKIdGk5vo8F97veNiZP7nZ4IuBfdjaQFwa436w==
   dependencies:
     "@citation-js/core" "^0.5.0"
@@ -2513,7 +2513,7 @@
 
 "@citation-js/core@0.5.0", "@citation-js/core@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fcore/-/core-0.5.0.tgz#0d90f7cec15b1e9ce4db259634c2951384792329"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fcore/-/core-0.5.0.tgz#0d90f7cec15b1e9ce4db259634c2951384792329"
   integrity sha512-3CjODmBJK6edZALxN+A8imLFXZKfu2uFa+ueu85jqUI6E8uVtggPM5Tn58+WVoHaUBYGWW5Lc4UM/wYzJPDVcQ==
   dependencies:
     "@citation-js/date" "^0.4.4"
@@ -2523,17 +2523,17 @@
 
 "@citation-js/date@0.4.4", "@citation-js/date@^0.4.4":
   version "0.4.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fdate/-/date-0.4.4.tgz#2e90b3c04b8b4861b331274916c3cc3e57860628"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fdate/-/date-0.4.4.tgz#2e90b3c04b8b4861b331274916c3cc3e57860628"
   integrity sha512-wD195pZPwCCN8idhxz4HYZbf5mMnPZMRhOipcU8v1orZWqZp6YDRjOplNKo6yX7tf6fB4ZO8QLuNaNjuic5AWQ==
 
 "@citation-js/name@0.4.2", "@citation-js/name@^0.4.2":
   version "0.4.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fname/-/name-0.4.2.tgz#8dc834b7e6c06998fc8d3b63632658754c94a875"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fname/-/name-0.4.2.tgz#8dc834b7e6c06998fc8d3b63632658754c94a875"
   integrity sha512-brSPsjs2fOVzSnARLKu0qncn6suWjHVQtrqSUrnqyaRH95r/Ad4wPF5EsoWr+Dx8HzkCGb/ogmoAzfCsqlTwTQ==
 
 "@citation-js/plugin-bibjson@0.5.0", "@citation-js/plugin-bibjson@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-bibjson/-/plugin-bibjson-0.5.0.tgz#19713ce14c83266a3c0b7462525dac218d873482"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-bibjson/-/plugin-bibjson-0.5.0.tgz#19713ce14c83266a3c0b7462525dac218d873482"
   integrity sha512-1IiR2YiRMj2haEm2cDrEdOAxaYMb42oIpqq0ppTEO3rcwfkiv7MJOleTncPvg2mIB4JQFFlhxTkcSrqY/QeHcg==
   dependencies:
     "@citation-js/date" "^0.4.4"
@@ -2541,7 +2541,7 @@
 
 "@citation-js/plugin-bibtex@0.5.0", "@citation-js/plugin-bibtex@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-bibtex/-/plugin-bibtex-0.5.0.tgz#b8920cad3e54a760dcb64bf96b70a4d302c0e33f"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-bibtex/-/plugin-bibtex-0.5.0.tgz#b8920cad3e54a760dcb64bf96b70a4d302c0e33f"
   integrity sha512-3R9LkmWUQ69fnNsQ+IGY5307zFYAKf5vr14NT1+TdnarGvGRlHkF3B3wk9TK2/d8pGgg7pi4oiuF9VmGBSIaMw==
   dependencies:
     "@citation-js/date" "^0.4.4"
@@ -2550,19 +2550,19 @@
 
 "@citation-js/plugin-csl@0.5.0", "@citation-js/plugin-csl@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-csl/-/plugin-csl-0.5.0.tgz#d4913ea80ea82b814fb5774344e181fbfe767bf8"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-csl/-/plugin-csl-0.5.0.tgz#d4913ea80ea82b814fb5774344e181fbfe767bf8"
   integrity sha512-dCPwdELFoPbgedxWK+Rj+zvkkQ8PQoPEOwzW9f4JgfIuj/jXlpsUX/SgJGJrzHGkQYYkmTkBx6LcEDNoGS62sw==
   dependencies:
     citeproc "^2.4.6"
 
 "@citation-js/plugin-doi@0.5.0", "@citation-js/plugin-doi@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-doi/-/plugin-doi-0.5.0.tgz#53935d1e2a2d4dc488d329845c4442218afa9c82"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-doi/-/plugin-doi-0.5.0.tgz#53935d1e2a2d4dc488d329845c4442218afa9c82"
   integrity sha512-oJ5KW6+BxVkkf5mWAoAiqmxi1III+Ot9q0ac1gwzN6+eM3j4WC9JU8iEGLfiHY8GbfwqsxVPyhNfA1+JbJ8m6g==
 
 "@citation-js/plugin-ris@0.5.0", "@citation-js/plugin-ris@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-ris/-/plugin-ris-0.5.0.tgz#4de7fe249d28f1152d8701ad68d2acbe0f2ebc0b"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-ris/-/plugin-ris-0.5.0.tgz#4de7fe249d28f1152d8701ad68d2acbe0f2ebc0b"
   integrity sha512-GENH2d16oO1yuk6FJEhQ5H8U28MdJ85wGHzBmbCFgkoyPwwYREg8yF8gVHo7oQZkbzrshpSvZ9QDtAVMABSB2w==
   dependencies:
     "@citation-js/date" "^0.4.4"
@@ -2570,7 +2570,7 @@
 
 "@citation-js/plugin-wikidata@0.5.0", "@citation-js/plugin-wikidata@^0.5.0":
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@citation-js%2fplugin-wikidata/-/plugin-wikidata-0.5.0.tgz#11b0eddbe25ccbd3ba254f00a272570854baca0f"
+  resolved "https://registry.yarnpkg.com/@citation-js%2fplugin-wikidata/-/plugin-wikidata-0.5.0.tgz#11b0eddbe25ccbd3ba254f00a272570854baca0f"
   integrity sha512-7jIs1bpOVWckcPNTWhyjYxiJ+cFkotwSr9bqTSa5e18MLQkS0Z6YmiF0pCjQyJ0wrLaMDS0ZLDgklAHIyMqoHw==
   dependencies:
     "@citation-js/date" "^0.4.4"
@@ -2579,12 +2579,12 @@
 
 "@colors/colors@1.5.0":
   version "1.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@colors%2fcolors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  resolved "https://registry.yarnpkg.com/@colors%2fcolors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
 "@cypress/request@^2.88.10":
   version "2.88.10"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@cypress%2frequest/-/request-2.88.10.tgz#b66d76b07f860d3a4b8d7a0604d020c662752cce"
+  resolved "https://registry.yarnpkg.com/@cypress%2frequest/-/request-2.88.10.tgz#b66d76b07f860d3a4b8d7a0604d020c662752cce"
   integrity sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==
   dependencies:
     aws-sign2 "~0.7.0"
@@ -2608,7 +2608,7 @@
 
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@cypress%2fxvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
+  resolved "https://registry.yarnpkg.com/@cypress%2fxvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
   integrity sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
   dependencies:
     debug "^3.1.0"
@@ -2616,7 +2616,7 @@
 
 "@devseed-ui/accordion@^3.0.4":
   version "3.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2faccordion/-/accordion-3.0.4.tgz#2846a756428af91bd8b8724f90a57ed53c3c1b6c"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2faccordion/-/accordion-3.0.4.tgz#2846a756428af91bd8b8724f90a57ed53c3c1b6c"
   integrity sha512-Pf/8FjxVOQDm2up2rpSOXxprM+RNKAu1MmewBLRdJdBC3NA+pTcrb9SpoZyeONljDNPYTW/hzBMQ3Z1XeotLbg==
   dependencies:
     "@devseed-ui/button" "3.1.0"
@@ -2630,7 +2630,7 @@
 
 "@devseed-ui/button@3.1.0":
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fbutton/-/button-3.1.0.tgz#74610d3fb62011d6d1985fd8b51125f131dc35d2"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fbutton/-/button-3.1.0.tgz#74610d3fb62011d6d1985fd8b51125f131dc35d2"
   integrity sha512-R0tDzmzd9wBfB4CBpYw3xcs12DCYLlmb5gLfaPgHMXVF0+pwUWxqa+GSQf7kAYurQ5YDkF5ukJ1HZiwiNkzJ0Q==
   dependencies:
     "@devseed-ui/collecticons" "3.2.0"
@@ -2638,12 +2638,12 @@
 
 "@devseed-ui/collecticons@3.2.0":
   version "3.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fcollecticons/-/collecticons-3.2.0.tgz#3b7ce315bcc60be39fe2c780c0cd94a74cd55b89"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fcollecticons/-/collecticons-3.2.0.tgz#3b7ce315bcc60be39fe2c780c0cd94a74cd55b89"
   integrity sha512-xO/gm1y+WdH433MWhaqtBGlZvyi5wJDo2fCJn/ODXz4JPB64WDc7qElxQFOg9osk4r4CvdK9eGx4gY343+RjMQ==
 
 "@devseed-ui/dropdown@2.0.4":
   version "2.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fdropdown/-/dropdown-2.0.4.tgz#0be064ba8120a4bf59cbf97ae2d27aafe3ad8ec2"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fdropdown/-/dropdown-2.0.4.tgz#0be064ba8120a4bf59cbf97ae2d27aafe3ad8ec2"
   integrity sha512-46RRGkTog6lUIfYaYrtT3jezkZHmVi6DgyOMOZY9rKIHqIzrJ/9gWBX7SK7cQRMslCiCj62SPbqMMr6jYfSfTw==
   dependencies:
     "@devseed-ui/button" "3.1.0"
@@ -2655,7 +2655,7 @@
 
 "@devseed-ui/form@1.0.5":
   version "1.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fform/-/form-1.0.5.tgz#6876edb1f7c290ebd87598748ec365035bf85273"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fform/-/form-1.0.5.tgz#6876edb1f7c290ebd87598748ec365035bf85273"
   integrity sha512-4/8jVLkcuwAkQhouF0sUdiCom19HIxkzBPXfpU1JdfBFMFwtcyyC1XYw4w1kZHh6R0Q06LXn89bgx4/18OSqMg==
   dependencies:
     "@devseed-ui/animation" "^3.0.0"
@@ -2665,7 +2665,7 @@
 
 "@devseed-ui/global-loading@2.0.3":
   version "2.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fglobal-loading/-/global-loading-2.0.3.tgz#92c9c3ec3aa73c6b88c87e0010ac5d28adde10ff"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fglobal-loading/-/global-loading-2.0.3.tgz#92c9c3ec3aa73c6b88c87e0010ac5d28adde10ff"
   integrity sha512-MMeY4cT2eTkkSrWaFH2oqO1elf8BGngBEDiFEH48os11IPQp9ehft4LoRKbQDDv+ksZWHn6PEsjo93Mt8wWg6g==
   dependencies:
     "@devseed-ui/collecticons" "3.2.0"
@@ -2673,7 +2673,7 @@
 
 "@devseed-ui/modal@^3.0.3":
   version "3.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2fmodal/-/modal-3.0.3.tgz#0ac888f0a5ab9d77ba2ebe1adb350e68f320dfc3"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2fmodal/-/modal-3.0.3.tgz#0ac888f0a5ab9d77ba2ebe1adb350e68f320dfc3"
   integrity sha512-BtLe+dwTTQzCFI+PrsG9XyHVq76B7c4J5fzeKSrK3f3bBlIzcb+POygeHQQusRIwv2C2heZl5ZCNhoigF3X4Qw==
   dependencies:
     "@devseed-ui/theme-provider" "^3.0.0"
@@ -2697,7 +2697,7 @@
 
 "@devseed-ui/toolbar@2.1.2":
   version "2.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@devseed-ui%2ftoolbar/-/toolbar-2.1.2.tgz#7429fd4537721e43d87de7d520a3d9a92b157ec7"
+  resolved "https://registry.yarnpkg.com/@devseed-ui%2ftoolbar/-/toolbar-2.1.2.tgz#7429fd4537721e43d87de7d520a3d9a92b157ec7"
   integrity sha512-xpgbcmi3ApLB6KjUzTFeSFeUrOJvoNFGkjCDEjgyQp0XnRrkX9dj1TwTLoMXXBfyyweXX7QDPjTb/NxXPIzvSQ==
   dependencies:
     "@devseed-ui/button" "3.1.0"
@@ -2713,7 +2713,7 @@
 
 "@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
   version "11.1.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fcache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
+  resolved "https://registry.yarnpkg.com/@emotion%2fcache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
   integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
   dependencies:
     "@emotion/memoize" "^0.7.4"
@@ -2724,7 +2724,7 @@
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fhash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
+  resolved "https://registry.yarnpkg.com/@emotion%2fhash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
 "@emotion/is-prop-valid@^0.8.8":
@@ -2741,12 +2741,12 @@
 
 "@emotion/memoize@^0.7.4":
   version "0.7.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fmemoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  resolved "https://registry.yarnpkg.com/@emotion%2fmemoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
   integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/react@^11.1.1":
   version "11.1.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2freact/-/react-11.1.5.tgz#15e78f9822894cdc296e6f4e0688bac8120dfe66"
+  resolved "https://registry.yarnpkg.com/@emotion%2freact/-/react-11.1.5.tgz#15e78f9822894cdc296e6f4e0688bac8120dfe66"
   integrity sha512-xfnZ9NJEv9SU9K2sxXM06lzjK245xSeHRpUh67eARBm3PBHjjKIZlfWZ7UQvD0Obvw6ZKjlC79uHrlzFYpOB/Q==
   dependencies:
     "@babel/runtime" "^7.7.2"
@@ -2759,7 +2759,7 @@
 
 "@emotion/serialize@^1.0.0":
   version "1.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fserialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  resolved "https://registry.yarnpkg.com/@emotion%2fserialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
   integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
   dependencies:
     "@emotion/hash" "^0.8.0"
@@ -2770,7 +2770,7 @@
 
 "@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fsheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  resolved "https://registry.yarnpkg.com/@emotion%2fsheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
   integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
 
 "@emotion/stylis@^0.8.4":
@@ -2785,12 +2785,12 @@
 
 "@emotion/utils@^1.0.0":
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2futils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  resolved "https://registry.yarnpkg.com/@emotion%2futils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
 "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@emotion%2fweak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  resolved "https://registry.yarnpkg.com/@emotion%2fweak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@eslint/eslintrc@^0.3.0":
@@ -2829,17 +2829,17 @@
 
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@jridgewell%2fresolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
+  resolved "https://registry.yarnpkg.com/@jridgewell%2fresolve-uri/-/resolve-uri-3.0.5.tgz#68eb521368db76d040a6315cdb24bf2483037b9c"
   integrity sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
+  resolved "https://registry.yarnpkg.com/@jridgewell%2fsourcemap-codec/-/sourcemap-codec-1.4.11.tgz#771a1d8d744eeb71b6adb35808e1a6c7b9b8c8ec"
   integrity sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==
 
 "@jridgewell/trace-mapping@^0.3.0":
   version "0.3.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
+  resolved "https://registry.yarnpkg.com/@jridgewell%2ftrace-mapping/-/trace-mapping-0.3.4.tgz#f6a0832dffd5b8a6aaa633b7d9f8e8e94c83a0c3"
   integrity sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
@@ -2873,7 +2873,7 @@
 
 "@parcel/bundler-default@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fbundler-default/-/bundler-default-2.4.0.tgz#a3b88131601821514cd932b3b2ada226d7d3404d"
+  resolved "https://registry.yarnpkg.com/@parcel%2fbundler-default/-/bundler-default-2.4.0.tgz#a3b88131601821514cd932b3b2ada226d7d3404d"
   integrity sha512-RaXlxo0M51739Ko3bsOJpDBZlJ+cqkDoBTozNeSc65jS2TMBIBWLMapm8095qmty39OrgYNhzjgPiIlKDS/LWA==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -2884,7 +2884,7 @@
 
 "@parcel/cache@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcache/-/cache-2.4.0.tgz#aa83243a00ee861183c6a1ce880292c6c1175022"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcache/-/cache-2.4.0.tgz#aa83243a00ee861183c6a1ce880292c6c1175022"
   integrity sha512-oOudoAafrCAHQY0zkU7gVHG1pAGBUz9rht7Tx4WupTmAH0O0F5UnZs6XbjoBJaPHg+CYUXK7v9wQcrNA72E3GA==
   dependencies:
     "@parcel/fs" "2.4.0"
@@ -2894,21 +2894,21 @@
 
 "@parcel/codeframe@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcodeframe/-/codeframe-2.4.0.tgz#c9a78a558f9a5c628c162d5774e2223d236d9f20"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcodeframe/-/codeframe-2.4.0.tgz#c9a78a558f9a5c628c162d5774e2223d236d9f20"
   integrity sha512-PJ3W9Z0sjoS2CANyo50c+LEr9IRZrtu0WsVPSYZ5ZYRuSXrSa/6PcAlnkyDk2+hi7Od8ncT2bmDexl0Oar3Jyg==
   dependencies:
     chalk "^4.1.0"
 
 "@parcel/compressor-raw@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcompressor-raw/-/compressor-raw-2.4.0.tgz#25c701d5a3a4cea843f8d0806b9192a8b107f5d8"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcompressor-raw/-/compressor-raw-2.4.0.tgz#25c701d5a3a4cea843f8d0806b9192a8b107f5d8"
   integrity sha512-ZErX14fTc0gKIgtnuqW7Clfln4dpXWfUaJQQIf5C3x/LkpUeEhdXeKntkvSxOddDk2JpIKDwqzAxEMZUnDo4Nw==
   dependencies:
     "@parcel/plugin" "2.4.0"
 
 "@parcel/config-default@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fconfig-default/-/config-default-2.4.0.tgz#a9ec50b99923d6f589b44bf9fd476425879102aa"
+  resolved "https://registry.yarnpkg.com/@parcel%2fconfig-default/-/config-default-2.4.0.tgz#a9ec50b99923d6f589b44bf9fd476425879102aa"
   integrity sha512-pFOPBXPO6HGqNWTLkcK5i8haMOrRgUouUhcWPGWDpN9IPUYFK2E/O1E/uyMjIA1mSL3FnazI+jJwZ45NhKPpIA==
   dependencies:
     "@parcel/bundler-default" "2.4.0"
@@ -2944,7 +2944,7 @@
 
 "@parcel/core@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcore/-/core-2.4.0.tgz#c0533760f9d4f04757c69152aa9a6219828ac1ee"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcore/-/core-2.4.0.tgz#c0533760f9d4f04757c69152aa9a6219828ac1ee"
   integrity sha512-EWZ2UWtIuwDc3fgsKyyTLpNNPoG8Yk2L117ICWF/+cqY8z/wJHm2KwLbeplDeq524shav0GJ9O4CemP3JPx0Nw==
   dependencies:
     "@parcel/cache" "2.4.0"
@@ -2974,47 +2974,47 @@
 
 "@parcel/css-darwin-arm64@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-darwin-arm64/-/css-darwin-arm64-1.7.3.tgz#dcc0286f79b17cba945ff53915a9d34a1ce62c47"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-darwin-arm64/-/css-darwin-arm64-1.7.3.tgz#dcc0286f79b17cba945ff53915a9d34a1ce62c47"
   integrity sha512-m3HDY+Rh8HJxmLELKAvCpF59vLS7FWtgBODHxl8G9Jl2CnGtXpXvdpyeMxNsTE+2QuPC+a5QT7IeZAKb2Gjmxg==
 
 "@parcel/css-darwin-x64@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-darwin-x64/-/css-darwin-x64-1.7.3.tgz#fac0d5705606b2261562879ee153b65c7201c9c5"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-darwin-x64/-/css-darwin-x64-1.7.3.tgz#fac0d5705606b2261562879ee153b65c7201c9c5"
   integrity sha512-LuhweXKxVwrz/hjAOm9XNRMSL+p23px20nhSCASkyUP7Higaxza948W3TSQdoL3YyR+wQxQH8Yj+R/T8Tz3E3g==
 
 "@parcel/css-linux-arm-gnueabihf@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.7.3.tgz#43fa89d88954aba565ff2bbcd010e408d6ca6782"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-linux-arm-gnueabihf/-/css-linux-arm-gnueabihf-1.7.3.tgz#43fa89d88954aba565ff2bbcd010e408d6ca6782"
   integrity sha512-/pd9Em18zMvt7eDZAMpNBEwF7c4VPVhAtBOZ59ClFrsXCTDNYP7mSy0cwNgtLelCRZCGAQmZNBDNQPH7vO3rew==
 
 "@parcel/css-linux-arm64-gnu@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-linux-arm64-gnu/-/css-linux-arm64-gnu-1.7.3.tgz#8dd5d52a2cd0d2450a2b639956bf955277aa760a"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-linux-arm64-gnu/-/css-linux-arm64-gnu-1.7.3.tgz#8dd5d52a2cd0d2450a2b639956bf955277aa760a"
   integrity sha512-5aKiEhQK40riO4iVKzRqISzgYK+7Z7i3e6JTSz+/BHuQyHEUaBe/RuJ8Z0BDQtFz0HmWQlrQCd+7hd0Xgd8vYQ==
 
 "@parcel/css-linux-arm64-musl@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-linux-arm64-musl/-/css-linux-arm64-musl-1.7.3.tgz#2a784ffacf398a7422c98345eed8410d8afff9bb"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-linux-arm64-musl/-/css-linux-arm64-musl-1.7.3.tgz#2a784ffacf398a7422c98345eed8410d8afff9bb"
   integrity sha512-Wf7/aIueDED2JqBMfZvzbBAFSaPmd3TR28bD2pmP7CI/jZnm9vHVKMdOLgt9NKSSSjdGrp+VM410CsrUM7xcOw==
 
 "@parcel/css-linux-x64-gnu@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-linux-x64-gnu/-/css-linux-x64-gnu-1.7.3.tgz#102751d452642d078bd40a6c5c5b19d65da810ba"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-linux-x64-gnu/-/css-linux-x64-gnu-1.7.3.tgz#102751d452642d078bd40a6c5c5b19d65da810ba"
   integrity sha512-0ZADbuFklUrHC1p2uPY4BPcN07jUTMqJzr/SSdnGN2XiXgiVZGcDCMHUj0DvC9Vwy11DDM6Rnw4QBbKHG+QGjQ==
 
 "@parcel/css-linux-x64-musl@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-linux-x64-musl/-/css-linux-x64-musl-1.7.3.tgz#563090ba9825d7de7352700effd9e0b3a8d74cbb"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-linux-x64-musl/-/css-linux-x64-musl-1.7.3.tgz#563090ba9825d7de7352700effd9e0b3a8d74cbb"
   integrity sha512-mFWWM8lX2OIID81YQuDDt9zTqof0B7UcEcs0huE7Zbs60uLEEQupdf8iH0yh5EOhxPt3sRcQnGXf2QTrXdjIMA==
 
 "@parcel/css-win32-x64-msvc@1.7.3":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss-win32-x64-msvc/-/css-win32-x64-msvc-1.7.3.tgz#d69551721b74457c92bd625d566a6d1f20b7d268"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss-win32-x64-msvc/-/css-win32-x64-msvc-1.7.3.tgz#d69551721b74457c92bd625d566a6d1f20b7d268"
   integrity sha512-KUFEMQcoP7DG3QbsN21OxhjHkfQ1BARn7D9puX75bV5N1F1kv557aaLkQZiMsgiYOL4tmJvsdQXutG7x++3j4Q==
 
 "@parcel/css@^1.7.2":
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fcss/-/css-1.7.3.tgz#e8ac640888c0317fe15b329df169ce60b2fe92cb"
+  resolved "https://registry.yarnpkg.com/@parcel%2fcss/-/css-1.7.3.tgz#e8ac640888c0317fe15b329df169ce60b2fe92cb"
   integrity sha512-rgdRX4Uk31EvzH/mUScL0wdXtkci3U5N1W2pgam+9S10vQy4uONhWBepZ1tUCjONHLacGXr1jp3LbG/HI7LiTw==
   dependencies:
     detect-libc "^1.0.3"
@@ -3030,7 +3030,7 @@
 
 "@parcel/diagnostic@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fdiagnostic/-/diagnostic-2.4.0.tgz#0a94287851aee60e30f1e7f10582be274e0d1cf4"
+  resolved "https://registry.yarnpkg.com/@parcel%2fdiagnostic/-/diagnostic-2.4.0.tgz#0a94287851aee60e30f1e7f10582be274e0d1cf4"
   integrity sha512-TjWO/b2zMFhub5ouwGjazMm7iAUvdmXBfWmjrg4TBhUbhoQwBnyWfvMDtAYo7PcvXfxVPgPZv86Nv6Ym5H6cHQ==
   dependencies:
     json-source-map "^0.6.1"
@@ -3038,19 +3038,19 @@
 
 "@parcel/events@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fevents/-/events-2.4.0.tgz#7526ea17dd72d97d7f4d3717285e85a36f5ead8f"
+  resolved "https://registry.yarnpkg.com/@parcel%2fevents/-/events-2.4.0.tgz#7526ea17dd72d97d7f4d3717285e85a36f5ead8f"
   integrity sha512-DEaEtFbhOhNAEmiXJ3MyF8Scq+sNDKiTyLax4lAC5/dpE5GvwfNnoD17C2+0gDuuDpdQkdHfXfvr50aYFt7jcw==
 
 "@parcel/fs-search@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ffs-search/-/fs-search-2.4.0.tgz#1f278eb56ee054521ccb7e685886cd386e5efba7"
+  resolved "https://registry.yarnpkg.com/@parcel%2ffs-search/-/fs-search-2.4.0.tgz#1f278eb56ee054521ccb7e685886cd386e5efba7"
   integrity sha512-W/Vu6wbZk4wuB6AVdMkyymwh/S8Peed/PgJgSsApYD6lSTD315I6OuEdxZh3lWY+dqQdog/NJ7dvi/hdpH/Iqw==
   dependencies:
     detect-libc "^1.0.3"
 
 "@parcel/fs@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ffs/-/fs-2.4.0.tgz#d8a34e63356ce66e3e34a958fae052d48acd2d28"
+  resolved "https://registry.yarnpkg.com/@parcel%2ffs/-/fs-2.4.0.tgz#d8a34e63356ce66e3e34a958fae052d48acd2d28"
   integrity sha512-CnUlWGUJ52SJVQi8QnaAPPQZOADmHMV9D9aX9GLcDm5XLT3Em7vmesG4bNLdMLwzYuzAtenhcWmuRCACuYztHw==
   dependencies:
     "@parcel/fs-search" "2.4.0"
@@ -3061,7 +3061,7 @@
 
 "@parcel/graph@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fgraph/-/graph-2.4.0.tgz#a0a94baf102f456ba7c9e4e235fb677bbe0f9286"
+  resolved "https://registry.yarnpkg.com/@parcel%2fgraph/-/graph-2.4.0.tgz#a0a94baf102f456ba7c9e4e235fb677bbe0f9286"
   integrity sha512-5TZIAfDITkJCzgH4j4OQhnIvjV9IFwWqNBJanRl5QQTmKvdcODS3WbnK1SOJ+ZltcLVXMB+HNXmL0bX0tVolcw==
   dependencies:
     "@parcel/utils" "2.4.0"
@@ -3069,7 +3069,7 @@
 
 "@parcel/hash@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fhash/-/hash-2.4.0.tgz#4f85e42d94aa3c458a7d0b484852f5466799be1b"
+  resolved "https://registry.yarnpkg.com/@parcel%2fhash/-/hash-2.4.0.tgz#4f85e42d94aa3c458a7d0b484852f5466799be1b"
   integrity sha512-nB+wYNUhe6+G8M7vQhdeFXtpYJYwJgBHOPZ7Hd9O2jdlamWjDbw0t/u1dJbYvGJ8ZDtLDwiItawQVpuVdskQ9g==
   dependencies:
     detect-libc "^1.0.3"
@@ -3077,7 +3077,7 @@
 
 "@parcel/logger@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2flogger/-/logger-2.4.0.tgz#762b9431183557132c91419f2f7e5443837a4222"
+  resolved "https://registry.yarnpkg.com/@parcel%2flogger/-/logger-2.4.0.tgz#762b9431183557132c91419f2f7e5443837a4222"
   integrity sha512-DqfU0Zcs/0a7VBk+MsjJ80C66w4kM9EbkO3G12NIyEjNeG50ayW2CE9rUuJ91JaM9j0NFM1P82eyLpQPFFaVPw==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3085,14 +3085,14 @@
 
 "@parcel/markdown-ansi@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fmarkdown-ansi/-/markdown-ansi-2.4.0.tgz#688fa5e5f4765bde83f49fe298d8a2b416b3446f"
+  resolved "https://registry.yarnpkg.com/@parcel%2fmarkdown-ansi/-/markdown-ansi-2.4.0.tgz#688fa5e5f4765bde83f49fe298d8a2b416b3446f"
   integrity sha512-gPUP1xikxHiu2kFyPy35pfuVkFgAmcywO8YDQj7iYcB+k7l4QPpIYFYGXn2QADV4faf66ncMeTD4uYV8c0GqjQ==
   dependencies:
     chalk "^4.1.0"
 
 "@parcel/namer-default@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fnamer-default/-/namer-default-2.4.0.tgz#df1571f4f9104ae9bdb77887693b4b7f9d5c86a6"
+  resolved "https://registry.yarnpkg.com/@parcel%2fnamer-default/-/namer-default-2.4.0.tgz#df1571f4f9104ae9bdb77887693b4b7f9d5c86a6"
   integrity sha512-DfL+Gx0Tyoa0vsgRpNybXjuKbWNw8MTVpy7Dk7r0btfVsn1jy3SSwlxH4USf76gb00/pK6XBsMp9zn7Z8ePREQ==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3101,7 +3101,7 @@
 
 "@parcel/node-resolver-core@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fnode-resolver-core/-/node-resolver-core-2.4.0.tgz#394f186fc7d431f98ac72b9d3fe140e04a21dd7d"
+  resolved "https://registry.yarnpkg.com/@parcel%2fnode-resolver-core/-/node-resolver-core-2.4.0.tgz#394f186fc7d431f98ac72b9d3fe140e04a21dd7d"
   integrity sha512-qiN97XcfW2fYNoYuVEhNKuVPEJKj5ONQl0fqr/NEMmYvWz3bVKjgiXNJwW558elZvCI08gEbdxgyThpuFFQeKQ==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3110,7 +3110,7 @@
 
 "@parcel/optimizer-css@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2foptimizer-css/-/optimizer-css-2.4.0.tgz#50403ee54c0c165d279f7ec11aabdf3e1ed3d94d"
+  resolved "https://registry.yarnpkg.com/@parcel%2foptimizer-css/-/optimizer-css-2.4.0.tgz#50403ee54c0c165d279f7ec11aabdf3e1ed3d94d"
   integrity sha512-LQmjjOGsHEHKTJqfHR2eJyhWhLXvHP0uOAU+qopBttYYlB2J/vMK9RYAye5cyAb8bQmV8wAdi2mq9rnt7FMSPw==
   dependencies:
     "@parcel/css" "^1.7.2"
@@ -3123,7 +3123,7 @@
 
 "@parcel/optimizer-htmlnano@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2foptimizer-htmlnano/-/optimizer-htmlnano-2.4.0.tgz#620b3e7089de97c9dc619952b22d45b461b12747"
+  resolved "https://registry.yarnpkg.com/@parcel%2foptimizer-htmlnano/-/optimizer-htmlnano-2.4.0.tgz#620b3e7089de97c9dc619952b22d45b461b12747"
   integrity sha512-02EbeElLgNOAYhGU7fFBahpoKrX5G/yzahpaoKB/ypScM4roSsAMBkGcluboR5L10YRsvfvJEpxvfGyDA3tPmw==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3134,7 +3134,7 @@
 
 "@parcel/optimizer-image@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2foptimizer-image/-/optimizer-image-2.4.0.tgz#2717210bd2e0a9c58af08394011cdd2f3c1172ce"
+  resolved "https://registry.yarnpkg.com/@parcel%2foptimizer-image/-/optimizer-image-2.4.0.tgz#2717210bd2e0a9c58af08394011cdd2f3c1172ce"
   integrity sha512-Q4onaBMPkDyYxPzrb8ytBUftaQZFepj9dSUgq+ETuHDzkgia0tomDPfCqrw6ld0qvYyANzXTP5+LC4g0i5yh+A==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3145,7 +3145,7 @@
 
 "@parcel/optimizer-svgo@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2foptimizer-svgo/-/optimizer-svgo-2.4.0.tgz#7abfaaa3e6ba3ade4d85a85705a8b307487d2feb"
+  resolved "https://registry.yarnpkg.com/@parcel%2foptimizer-svgo/-/optimizer-svgo-2.4.0.tgz#7abfaaa3e6ba3ade4d85a85705a8b307487d2feb"
   integrity sha512-mwvGuCqVuNCAuMlp2maFE/Uz9ud1T1AuX0f6cCRczjFYiwZuIr/0iDdfFzSziOkVo1MRAGAZNa0dRR/UzCZtVg==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3155,7 +3155,7 @@
 
 "@parcel/optimizer-terser@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2foptimizer-terser/-/optimizer-terser-2.4.0.tgz#433965117d54c4cf113af3a6b056ff0766367468"
+  resolved "https://registry.yarnpkg.com/@parcel%2foptimizer-terser/-/optimizer-terser-2.4.0.tgz#433965117d54c4cf113af3a6b056ff0766367468"
   integrity sha512-PdCgRgXNSY6R1HTV9VG2MHp1CgUbP5pslCyxvlbUmQAS6bvEpMOpn3qSd+U28o7mGE/qXIhvpDyi808sb+MEcg==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3167,7 +3167,7 @@
 
 "@parcel/package-manager@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackage-manager/-/package-manager-2.4.0.tgz#ab4d7a53059355dc4f17e16c97540b6c7d70c5f6"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackage-manager/-/package-manager-2.4.0.tgz#ab4d7a53059355dc4f17e16c97540b6c7d70c5f6"
   integrity sha512-21AEfAQnZbHRVViTn7QsPGe/CiGaFaDUH5f0m8qVC7fDjjhC8LM8blkqU72goaO9FbaLMadtEf2txhzly7h/bg==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3180,7 +3180,7 @@
 
 "@parcel/packager-css@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackager-css/-/packager-css-2.4.0.tgz#02198953674172c20a1c00418fdc7a1671f62fad"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackager-css/-/packager-css-2.4.0.tgz#02198953674172c20a1c00418fdc7a1671f62fad"
   integrity sha512-LmPDWzkXi60Oy3WrPF0jPKQxeTwW5hmNBgrcXJMHSu+VcXdaQZNzNxVzhnZkJUbDd2z9vAUrUGzdLh8TquC8iQ==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3190,7 +3190,7 @@
 
 "@parcel/packager-html@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackager-html/-/packager-html-2.4.0.tgz#a14a4e8de19dc16c5e2c611c7d0cce7b9af9aef1"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackager-html/-/packager-html-2.4.0.tgz#a14a4e8de19dc16c5e2c611c7d0cce7b9af9aef1"
   integrity sha512-OPMIQ1uHYQFpRPrsmm5BqONbAyzjlhVsPRAzHlcBrglG4BTUeOR2ow4MUKblHmVVqc3QHnfZG4nHHtFkeuNQ3A==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3201,7 +3201,7 @@
 
 "@parcel/packager-js@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackager-js/-/packager-js-2.4.0.tgz#033e80a161c14793ac47b74da84a2c8a22b23b76"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackager-js/-/packager-js-2.4.0.tgz#033e80a161c14793ac47b74da84a2c8a22b23b76"
   integrity sha512-cfslIH43CJFgBS9PmdFaSnbInMCoejsFCnxtJa2GeUpjCXSfelPRp0OPx7m8n+fap4czftPhoxBALeDUElOZGQ==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3214,14 +3214,14 @@
 
 "@parcel/packager-raw@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackager-raw/-/packager-raw-2.4.0.tgz#bdb2576f154e897947bf6331d7711d4a6258d1e8"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackager-raw/-/packager-raw-2.4.0.tgz#bdb2576f154e897947bf6331d7711d4a6258d1e8"
   integrity sha512-SFfw7chMFITj3J26ZVDJxbO6xwtPFcFBm1js8cwWMgzwuwS6CEc43k5+Abj+2/EqHU9kNJU9eWV5vT6lQwf3HA==
   dependencies:
     "@parcel/plugin" "2.4.0"
 
 "@parcel/packager-svg@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fpackager-svg/-/packager-svg-2.4.0.tgz#573653b582472aaad77beb9a9cb1421d744bd3b5"
+  resolved "https://registry.yarnpkg.com/@parcel%2fpackager-svg/-/packager-svg-2.4.0.tgz#573653b582472aaad77beb9a9cb1421d744bd3b5"
   integrity sha512-DwkgrdLEQop+tu9Ocr1ZaadmpsbSgVruJPr80xq1LaB0Jiwrl9HjHStMNH1laNFueK1yydxhnj9C2JQfW28qag==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3231,14 +3231,14 @@
 
 "@parcel/plugin@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fplugin/-/plugin-2.4.0.tgz#fc940f4eb58dc271e53aa0043b68cc565853e390"
+  resolved "https://registry.yarnpkg.com/@parcel%2fplugin/-/plugin-2.4.0.tgz#fc940f4eb58dc271e53aa0043b68cc565853e390"
   integrity sha512-ehFUAL2+h27Lv+cYbbXA74UGy8C+eglUjcpvASOOjVRFuD6poMAMliKkKAXBhQaFx/Rvhz27A2PIPv9lL2i4UQ==
   dependencies:
     "@parcel/types" "2.4.0"
 
 "@parcel/reporter-bundle-analyzer@^2.0.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2freporter-bundle-analyzer/-/reporter-bundle-analyzer-2.4.0.tgz#0f95702419f4a5dd8764ca89ad856b98a37ac970"
+  resolved "https://registry.yarnpkg.com/@parcel%2freporter-bundle-analyzer/-/reporter-bundle-analyzer-2.4.0.tgz#0f95702419f4a5dd8764ca89ad856b98a37ac970"
   integrity sha512-fzqj/NcUzKpECHPPa/iR+VrC5Hk9Pp5twSxvweG8PQbanMRiyj2xmxOv4uyM00Gsmtx/RwL1bFkcWEZ9/Muprg==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3247,14 +3247,14 @@
 
 "@parcel/reporter-bundle-buddy@^2.0.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2freporter-bundle-buddy/-/reporter-bundle-buddy-2.4.0.tgz#9e5cce24b7534464deb3810d2f2e8d7c386e9cc2"
+  resolved "https://registry.yarnpkg.com/@parcel%2freporter-bundle-buddy/-/reporter-bundle-buddy-2.4.0.tgz#9e5cce24b7534464deb3810d2f2e8d7c386e9cc2"
   integrity sha512-xnAZP8atg4ojeSIRnTeiyoC+Q50lRjZsx3rfnfCwulfpepFPpAfaEcgUb02abUyFCXQ52KnVHUQctX6tGizgOg==
   dependencies:
     "@parcel/plugin" "2.4.0"
 
 "@parcel/reporter-cli@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2freporter-cli/-/reporter-cli-2.4.0.tgz#37ba4e12b1999c04beeaf98cb6809cd4794acae4"
+  resolved "https://registry.yarnpkg.com/@parcel%2freporter-cli/-/reporter-cli-2.4.0.tgz#37ba4e12b1999c04beeaf98cb6809cd4794acae4"
   integrity sha512-Q9bIFMaGvQgypCDxdMEKOwrJzIHAXScKkuFsqTHnUL6mmH3Mo2CoEGAq/wpMXuPhXRn1dPJcHgTNDwZ2fSzz0A==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3265,7 +3265,7 @@
 
 "@parcel/reporter-dev-server@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2freporter-dev-server/-/reporter-dev-server-2.4.0.tgz#233e595680aa86ae599715589865b282abdf63bd"
+  resolved "https://registry.yarnpkg.com/@parcel%2freporter-dev-server/-/reporter-dev-server-2.4.0.tgz#233e595680aa86ae599715589865b282abdf63bd"
   integrity sha512-24h++wevs7XYuX4dKa4PUfLSstvn3g7udajFv6CeQoME+dR25RL/wH/2LUbhV5ilgXXab76rWIndSqp78xHxPA==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3273,7 +3273,7 @@
 
 "@parcel/resolver-default@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fresolver-default/-/resolver-default-2.4.0.tgz#1f45b95443078f10d178b32782da95a1bea71eb6"
+  resolved "https://registry.yarnpkg.com/@parcel%2fresolver-default/-/resolver-default-2.4.0.tgz#1f45b95443078f10d178b32782da95a1bea71eb6"
   integrity sha512-K7pIIFmGm1hjg/7Mzkg99i8tfCClKfBUTuc2R5j8cdr2n0mCAi4/f2mFf5svLrb5XZrnDgoQ05tHKklLEfUDUw==
   dependencies:
     "@parcel/node-resolver-core" "2.4.0"
@@ -3281,7 +3281,7 @@
 
 "@parcel/runtime-browser-hmr@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fruntime-browser-hmr/-/runtime-browser-hmr-2.4.0.tgz#369b688ce3ed95109c0fcff9157b678c5ee033db"
+  resolved "https://registry.yarnpkg.com/@parcel%2fruntime-browser-hmr/-/runtime-browser-hmr-2.4.0.tgz#369b688ce3ed95109c0fcff9157b678c5ee033db"
   integrity sha512-swPFtvxGoCA9LEjU/pHPNjxG1l0fte8447zXwRN/AaYrtjNu9Ww117OSKCyvCnE143E79jZOFStodTQGFuH+9A==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3289,7 +3289,7 @@
 
 "@parcel/runtime-js@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fruntime-js/-/runtime-js-2.4.0.tgz#bcf6d540247bda286156a876efdbf9103ce03978"
+  resolved "https://registry.yarnpkg.com/@parcel%2fruntime-js/-/runtime-js-2.4.0.tgz#bcf6d540247bda286156a876efdbf9103ce03978"
   integrity sha512-67OOvmkDdtmgzZVP/EyAzoXhJ/Ug3LUVUt7idg9arun5rdJptqEb3Um3wmH0zjcNa9jMbJt7Kl5x1wA8dJgPYg==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3298,7 +3298,7 @@
 
 "@parcel/runtime-react-refresh@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fruntime-react-refresh/-/runtime-react-refresh-2.4.0.tgz#fe305175228c8d19d8fba9bed5542fad549723ce"
+  resolved "https://registry.yarnpkg.com/@parcel%2fruntime-react-refresh/-/runtime-react-refresh-2.4.0.tgz#fe305175228c8d19d8fba9bed5542fad549723ce"
   integrity sha512-flnr+bf06lMZPbXZZLLaFNrPHvYpfuXTVovEghyUW46qLVpaHj33dpsU/LqZplIuHgBp2ibgrKhr/hY9ell68w==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3307,7 +3307,7 @@
 
 "@parcel/runtime-service-worker@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fruntime-service-worker/-/runtime-service-worker-2.4.0.tgz#07375693acbd9a5940e6230409099e0861362cc3"
+  resolved "https://registry.yarnpkg.com/@parcel%2fruntime-service-worker/-/runtime-service-worker-2.4.0.tgz#07375693acbd9a5940e6230409099e0861362cc3"
   integrity sha512-RgM5QUqW22WzstW03CtV+Oih8VGVuwsf94Cc4hLouU2EAD0NUJgATWbFocZVTZIBTKELAWh2gjpSQDdnL4Ur+A==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3316,14 +3316,14 @@
 
 "@parcel/source-map@^2.0.0":
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fsource-map/-/source-map-2.0.2.tgz#9aa0b00518cee31d5634de6e9c924a5539b142c1"
+  resolved "https://registry.yarnpkg.com/@parcel%2fsource-map/-/source-map-2.0.2.tgz#9aa0b00518cee31d5634de6e9c924a5539b142c1"
   integrity sha512-NnUrPYLpYB6qyx2v6bcRPn/gVigmGG6M6xL8wIg/i0dP1GLkuY1nf+Hqdf63FzPTqqT7K3k6eE5yHPQVMO5jcA==
   dependencies:
     detect-libc "^1.0.3"
 
 "@parcel/transformer-babel@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-babel/-/transformer-babel-2.4.0.tgz#05d1661293debbccacd11218c3729b7e5a2dfe1c"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-babel/-/transformer-babel-2.4.0.tgz#05d1661293debbccacd11218c3729b7e5a2dfe1c"
   integrity sha512-iWDa7KzJTMP3HNmrYxiYq/S6redk2qminx/9MwmKIN9jzm8mgts2Lj9lOg/t66YaDGky6JAvw4DhB2qW4ni6yQ==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3337,7 +3337,7 @@
 
 "@parcel/transformer-css@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-css/-/transformer-css-2.4.0.tgz#7b7e35ccbe343ff0c768a330712d1756ca7f7b4c"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-css/-/transformer-css-2.4.0.tgz#7b7e35ccbe343ff0c768a330712d1756ca7f7b4c"
   integrity sha512-D2u48LuiQsQvbknABE0wVKFp9r6yCgWrHKEP1J6EJ31c49nXGXDHrpHJJwqq9BvAs/124eBI5mSsehTJyFEMwg==
   dependencies:
     "@parcel/css" "^1.7.2"
@@ -3350,7 +3350,7 @@
 
 "@parcel/transformer-html@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-html/-/transformer-html-2.4.0.tgz#9b342f4041d319d9759607be0aec4c1ff4ad7739"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-html/-/transformer-html-2.4.0.tgz#9b342f4041d319d9759607be0aec4c1ff4ad7739"
   integrity sha512-2/8X/o5QaCNVPr4wkxLCUub7v/YVvVN2L5yCEcTatNeFhNg/2iz7P2ekfqOaoDCHWZEOBT1VTwPbdBt+TMM71Q==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3364,7 +3364,7 @@
 
 "@parcel/transformer-image@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-image/-/transformer-image-2.4.0.tgz#3ce2603343aaf045f9dba6cd1b98ee5df060450d"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-image/-/transformer-image-2.4.0.tgz#3ce2603343aaf045f9dba6cd1b98ee5df060450d"
   integrity sha512-JZkQvGGoGiD0AVKLIbAYYUWxepMmUaWZ4XXx71MmS/kA7cUDwTZ0CXq63YnSY1m+DX+ClTuTN8mBlwe2dkcGbA==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3373,7 +3373,7 @@
 
 "@parcel/transformer-js@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-js/-/transformer-js-2.4.0.tgz#e07310ef85a4c14e3d285c3c85e73c581043dfaf"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-js/-/transformer-js-2.4.0.tgz#e07310ef85a4c14e3d285c3c85e73c581043dfaf"
   integrity sha512-eeLHFwv3jT3GmIxpLC7B8EXExGK0MFaK91HXljOMh6l8a+GlQYw27MSFQVtoXr0Olx9Uq2uvjXP1+zSsq3LQUQ==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3390,7 +3390,7 @@
 
 "@parcel/transformer-json@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-json/-/transformer-json-2.4.0.tgz#575497fb64029071cadcf1309884c0ec4e5def3c"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-json/-/transformer-json-2.4.0.tgz#575497fb64029071cadcf1309884c0ec4e5def3c"
   integrity sha512-3nR+d39mbURoXIypDfVCaxpwL65qMV+h8SLD78up2uhaRGklHQfN7GuemR7L+mcVAgNrmwVvZHhyNjdgYwWqqg==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3398,7 +3398,7 @@
 
 "@parcel/transformer-postcss@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-postcss/-/transformer-postcss-2.4.0.tgz#8b968be108e2e0280c3ae025df29b14e83ec8c50"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-postcss/-/transformer-postcss-2.4.0.tgz#8b968be108e2e0280c3ae025df29b14e83ec8c50"
   integrity sha512-ijIa2x+dbKnJhr7zO5WlXkvuj832fDoGksMBk2DX3u2WMrbh2rqVWPpGFsDhESx7EAy38nUoV/5KUdrNqUmCEA==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3412,7 +3412,7 @@
 
 "@parcel/transformer-posthtml@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-posthtml/-/transformer-posthtml-2.4.0.tgz#89d9f2e96a69d52fe56ca9710e9a177a61097f43"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-posthtml/-/transformer-posthtml-2.4.0.tgz#89d9f2e96a69d52fe56ca9710e9a177a61097f43"
   integrity sha512-xoL3AzgtVeRRAo6bh0AHAYm9bt1jZ+HiH86/7oARj/uJs6Wd8kXK/DZf6fH+F87hj4e7bnjmDDc0GPVK0lPz1w==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3425,14 +3425,14 @@
 
 "@parcel/transformer-raw@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-raw/-/transformer-raw-2.4.0.tgz#ee65c296073ce3876b1380be20721105e3a6d9c7"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-raw/-/transformer-raw-2.4.0.tgz#ee65c296073ce3876b1380be20721105e3a6d9c7"
   integrity sha512-fciFbNrzj0kLlDgr6OsI0PUv414rVygDWAsgbCCq4BexDkuemMs9f9FjMctx9B2VZlctE8dTT4RGkuQumTIpUg==
   dependencies:
     "@parcel/plugin" "2.4.0"
 
 "@parcel/transformer-react-refresh-wrap@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.0.tgz#23d1a39acddbbe71802c962f88ef376548c94cf8"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.0.tgz#23d1a39acddbbe71802c962f88ef376548c94cf8"
   integrity sha512-9+f6sGOWkf0jyUQ1CuFWk+04Mq3KTOCU9kRiwCHX1YdUCv5uki6r9XUSpqiYodrV+L6w9CCwLvGMLCDHxtCxMg==
   dependencies:
     "@parcel/plugin" "2.4.0"
@@ -3441,7 +3441,7 @@
 
 "@parcel/transformer-svg@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftransformer-svg/-/transformer-svg-2.4.0.tgz#07f7a19e7da1ec115b2fb49e364c18cc0f445ddf"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftransformer-svg/-/transformer-svg-2.4.0.tgz#07f7a19e7da1ec115b2fb49e364c18cc0f445ddf"
   integrity sha512-D+yzVtSxtQML3d26fd/g4E/xYW68+OMbMUVLXORtoYMU42fnXQkJP6jGOdqy8Td+WORNY7EwVtQnESLwhBmolw==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3455,7 +3455,7 @@
 
 "@parcel/types@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2ftypes/-/types-2.4.0.tgz#e900ba9d9c14cc8bc783724e7c66f04b87965b28"
+  resolved "https://registry.yarnpkg.com/@parcel%2ftypes/-/types-2.4.0.tgz#e900ba9d9c14cc8bc783724e7c66f04b87965b28"
   integrity sha512-nysGIbBEnp+7R+tKTysdcTFOZDTCodsiXFeAhYQa5bhiOnG1l9gzhxQnE2OsdsgvMm40IOsgKprqvM/DbdLfnQ==
   dependencies:
     "@parcel/cache" "2.4.0"
@@ -3468,7 +3468,7 @@
 
 "@parcel/utils@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2futils/-/utils-2.4.0.tgz#47f979e10f82caac160a6526db2f31c5713ca0d7"
+  resolved "https://registry.yarnpkg.com/@parcel%2futils/-/utils-2.4.0.tgz#47f979e10f82caac160a6526db2f31c5713ca0d7"
   integrity sha512-sdNo+mZqDZT8LJYB6WWRKa4wFVZcK6Zb5Jh6Du76QvXXwHbPIQNZgJBb6gd/Rbk4GLOp2tW7MnBfq6zP9E9E2g==
   dependencies:
     "@parcel/codeframe" "2.4.0"
@@ -3481,7 +3481,7 @@
 
 "@parcel/watcher@^2.0.0":
   version "2.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fwatcher/-/watcher-2.0.5.tgz#f913a54e1601b0aac972803829b0eece48de215b"
+  resolved "https://registry.yarnpkg.com/@parcel%2fwatcher/-/watcher-2.0.5.tgz#f913a54e1601b0aac972803829b0eece48de215b"
   integrity sha512-x0hUbjv891omnkcHD7ZOhiyyUqUUR6MNjq89JhEI3BxppeKWAm6NPQsqqRrAkCJBogdT/o/My21sXtTI9rJIsw==
   dependencies:
     node-addon-api "^3.2.1"
@@ -3489,7 +3489,7 @@
 
 "@parcel/workers@2.4.0":
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@parcel%2fworkers/-/workers-2.4.0.tgz#393d5fe7942220b8846f626688e341c1be2bf1fa"
+  resolved "https://registry.yarnpkg.com/@parcel%2fworkers/-/workers-2.4.0.tgz#393d5fe7942220b8846f626688e341c1be2bf1fa"
   integrity sha512-eSFyvEoXXPgFzQfKIlpkUjpHfIbezUCRFTPKyJAKCxvU5DSXOpb1kz5vDESWQ4qTZXKnrKvxS1PPWN6bam9z0g==
   dependencies:
     "@parcel/diagnostic" "2.4.0"
@@ -3526,14 +3526,14 @@
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.8.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sinonjs%2fcommons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
+  resolved "https://registry.yarnpkg.com/@sinonjs%2fcommons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
   integrity sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/formatio@^3.2.1":
   version "3.2.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sinonjs%2fformatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  resolved "https://registry.yarnpkg.com/@sinonjs%2fformatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
   integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
   dependencies:
     "@sinonjs/commons" "^1"
@@ -3541,7 +3541,7 @@
 
 "@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
   version "3.3.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sinonjs%2fsamsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  resolved "https://registry.yarnpkg.com/@sinonjs%2fsamsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
   integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
   dependencies:
     "@sinonjs/commons" "^1.3.0"
@@ -3550,7 +3550,7 @@
 
 "@sinonjs/text-encoding@^0.7.1":
   version "0.7.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@sinonjs%2ftext-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  resolved "https://registry.yarnpkg.com/@sinonjs%2ftext-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
 "@stylelint/postcss-css-in-js@^0.37.2":
@@ -3570,7 +3570,7 @@
 
 "@swc/helpers@^0.3.6":
   version "0.3.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@swc%2fhelpers/-/helpers-0.3.8.tgz#5b9ecf4ee480ca00f1ffbc2d1a5d4eed0d1afe81"
+  resolved "https://registry.yarnpkg.com/@swc%2fhelpers/-/helpers-0.3.8.tgz#5b9ecf4ee480ca00f1ffbc2d1a5d4eed0d1afe81"
   integrity sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg==
 
 "@tippyjs/react@^4.0.2":
@@ -3582,12 +3582,12 @@
 
 "@trysound/sax@0.2.0":
   version "0.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@trysound%2fsax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
+  resolved "https://registry.yarnpkg.com/@trysound%2fsax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
 "@types/cookie@^0.3.3":
   version "0.3.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fcookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  resolved "https://registry.yarnpkg.com/@types%2fcookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
   integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
 
 "@types/escape-html@^1.0.0":
@@ -3629,12 +3629,12 @@
 
 "@types/node@*":
   version "18.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fnode/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
+  resolved "https://registry.yarnpkg.com/@types%2fnode/-/node-18.0.6.tgz#0ba49ac517ad69abe7a1508bc9b3a5483df9d5d7"
   integrity sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==
 
 "@types/node@^14.14.31":
   version "14.18.22"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fnode/-/node-14.18.22.tgz#fd2a15dca290fc9ad565b672fde746191cd0c6e6"
+  resolved "https://registry.yarnpkg.com/@types%2fnode/-/node-14.18.22.tgz#fd2a15dca290fc9ad565b672fde746191cd0c6e6"
   integrity sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==
 
 "@types/normalize-package-data@^2.4.0":
@@ -3649,12 +3649,12 @@
 
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fsinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
+  resolved "https://registry.yarnpkg.com/@types%2fsinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
   integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
 "@types/sizzle@^2.3.2":
   version "2.3.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fsizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
+  resolved "https://registry.yarnpkg.com/@types%2fsizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
@@ -3664,7 +3664,7 @@
 
 "@types/yauzl@^2.9.1":
   version "2.10.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@types%2fyauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  resolved "https://registry.yarnpkg.com/@types%2fyauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
   integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
   dependencies:
     "@types/node" "*"
@@ -3699,12 +3699,12 @@
 
 "@udecode/slate-plugins-core@^0.75.2":
   version "0.75.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@udecode%2fslate-plugins-core/-/slate-plugins-core-0.75.2.tgz#f2d9a2be4809a8a117d549082815439ddedd5c5a"
+  resolved "https://registry.yarnpkg.com/@udecode%2fslate-plugins-core/-/slate-plugins-core-0.75.2.tgz#f2d9a2be4809a8a117d549082815439ddedd5c5a"
   integrity sha512-H+1ftpy0KAEe/1POqlCyYDbnpe+9JiFwfGuNpO9UcN60wyIdN819jAOfNYWrEKmZiYqmMPdwF7sv3unlRfRg2g==
 
 "@udecode/slate-plugins@0.75.2":
   version "0.75.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/@udecode%2fslate-plugins/-/slate-plugins-0.75.2.tgz#a1e66713c7196b70fb5662d0f4afb2a1bd1c2aa6"
+  resolved "https://registry.yarnpkg.com/@udecode%2fslate-plugins/-/slate-plugins-0.75.2.tgz#a1e66713c7196b70fb5662d0f4afb2a1bd1c2aa6"
   integrity sha512-h7W0Da6sJSY41WGzJJIRztDQH5G8Lwn0t270hrhHLO6ibPidJATFvSWwufTSEw/XBONFrcg6tvHsULmiw2o9cA==
   dependencies:
     "@react-hook/merged-ref" "^1.3.0"
@@ -3774,7 +3774,7 @@ JSV@^4.0.x:
 
 abortcontroller-polyfill@^1.1.9:
   version "1.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
   integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
 
 acorn-jsx@^5.3.1:
@@ -3789,7 +3789,7 @@ acorn@^7.4.0:
 
 acorn@^8.5.0:
   version "8.7.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 add-px-to-style@1.0.0:
@@ -3827,7 +3827,7 @@ ajv@^7.0.2:
 
 amazon-cognito-identity-js@5.0.3:
   version "5.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.0.3.tgz#4c3821a7870fb83ee56aa1bbd1d3bb6beba68aa8"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.0.3.tgz#4c3821a7870fb83ee56aa1bbd1d3bb6beba68aa8"
   integrity sha512-0qIL6brMF6Q/GeGlovcg+fNtmABGocy9uTJBCjcJ+LFxwyIzZhELbf0koBH9clXADMK6kp+U5TfcM/5S7DCDoQ==
   dependencies:
     buffer "4.9.2"
@@ -3850,12 +3850,12 @@ ansi-colors@^4.1.1:
 
 ansi-escapes@^3.2.0:
   version "3.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-escapes@^4.3.0:
   version "4.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
     type-fest "^0.21.3"
@@ -3874,12 +3874,12 @@ ansi-regex@^2.0.0:
 
 ansi-regex@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
 ansi-regex@^4.1.0:
   version "4.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-regex@^5.0.0:
@@ -3889,7 +3889,7 @@ ansi-regex@^5.0.0:
 
 ansi-regex@^5.0.1:
   version "5.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
@@ -3938,7 +3938,7 @@ append-buffer@^1.0.2:
 
 arch@^2.2.0:
   version "2.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
 
 archy@^1.0.0:
@@ -3955,7 +3955,7 @@ argparse@^1.0.7:
 
 argparse@^2.0.1:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
@@ -3999,7 +3999,7 @@ array-each@^1.0.0, array-each@^1.0.1:
 
 array-from@^2.1.1:
   version "2.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
   integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-includes@^3.1.1, array-includes@^3.1.2:
@@ -4085,7 +4085,7 @@ arrify@^1.0.1:
 
 asn1.js@^5.2.0:
   version "5.4.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
   integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
   dependencies:
     bn.js "^4.0.0"
@@ -4095,14 +4095,14 @@ asn1.js@^5.2.0:
 
 asn1@~0.2.3:
   version "0.2.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
+  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
   dependencies:
     safer-buffer "~2.1.0"
 
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
+  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
 assign-symbols@^1.0.0:
@@ -4139,24 +4139,24 @@ async-settle@^1.0.0:
 
 async@^2.6.0:
   version "2.6.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
   integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
   dependencies:
     lodash "^4.17.14"
 
 async@^3.2.0:
   version "3.2.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 at-least-node@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
@@ -4179,7 +4179,7 @@ autoprefixer@^9.8.6:
 
 aws-amplify@^4.1.1:
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/aws-amplify/-/aws-amplify-4.1.1.tgz#87e00fc140fe9489ac68aa8e6e45464003a7fc28"
+  resolved "https://registry.yarnpkg.com/aws-amplify/-/aws-amplify-4.1.1.tgz#87e00fc140fe9489ac68aa8e6e45464003a7fc28"
   integrity sha512-pgM9NXItBAPxD208fnibR/mlyIsgj6tBnb/JFLV/V2mrgieilMtSRZt5odvXYuGn3zuEIJCKQ6gm3thssrV3tw==
   dependencies:
     "@aws-amplify/analytics" "5.0.3"
@@ -4197,12 +4197,12 @@ aws-amplify@^4.1.1:
 
 aws-sign2@~0.7.0:
   version "0.7.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
   version "1.11.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axios@0.21.1, axios@^0.21.1:
@@ -4233,7 +4233,7 @@ babel-plugin-dynamic-import-node@^2.3.3:
 
 babel-plugin-polyfill-corejs2@^0.3.0:
   version "0.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz#440f1b70ccfaabc6b676d196239b138f8a2cfba5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz#440f1b70ccfaabc6b676d196239b138f8a2cfba5"
   integrity sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==
   dependencies:
     "@babel/compat-data" "^7.13.11"
@@ -4242,7 +4242,7 @@ babel-plugin-polyfill-corejs2@^0.3.0:
 
 babel-plugin-polyfill-corejs3@^0.5.0:
   version "0.5.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz#aabe4b2fa04a6e038b688c5e55d44e78cd3a5f72"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz#aabe4b2fa04a6e038b688c5e55d44e78cd3a5f72"
   integrity sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
@@ -4250,7 +4250,7 @@ babel-plugin-polyfill-corejs3@^0.5.0:
 
 babel-plugin-polyfill-regenerator@^0.3.0:
   version "0.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz#2c0678ea47c75c8cc2fbb1852278d8fb68233990"
   integrity sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.3.1"
@@ -4297,7 +4297,7 @@ balanced-match@^1.0.0:
 
 base-x@^3.0.8:
   version "3.0.9"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
   integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
   dependencies:
     safe-buffer "^5.0.1"
@@ -4322,7 +4322,7 @@ base@^0.11.1:
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
+  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
@@ -4354,29 +4354,29 @@ bl@^1.2.1:
 
 blob-util@^2.0.2:
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
+  resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
   integrity sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
 
 block-stream@*:
   version "0.0.9"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
 
 bluebird@^3.7.2:
   version "3.7.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   version "4.12.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
 bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
 boolbase@^1.0.0:
@@ -4386,7 +4386,7 @@ boolbase@^1.0.0:
 
 bowser@^2.11.0:
   version "2.11.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
   integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
 
 brace-expansion@^1.1.7:
@@ -4422,12 +4422,12 @@ braces@^3.0.1:
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
   dependencies:
     buffer-xor "^1.0.3"
@@ -4439,7 +4439,7 @@ browserify-aes@^1.0.0, browserify-aes@^1.0.4:
 
 browserify-cipher@^1.0.0:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
+  resolved "https://registry.yarnpkg.com/browserify-cipher/-/browserify-cipher-1.0.1.tgz#8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0"
   integrity sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==
   dependencies:
     browserify-aes "^1.0.4"
@@ -4448,7 +4448,7 @@ browserify-cipher@^1.0.0:
 
 browserify-des@^1.0.0:
   version "1.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
+  resolved "https://registry.yarnpkg.com/browserify-des/-/browserify-des-1.0.2.tgz#3af4f1f59839403572f1c66204375f7a7f703e9c"
   integrity sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==
   dependencies:
     cipher-base "^1.0.1"
@@ -4458,7 +4458,7 @@ browserify-des@^1.0.0:
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
   version "4.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
   integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
   dependencies:
     bn.js "^5.0.0"
@@ -4466,7 +4466,7 @@ browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
 
 browserify-sign@^4.0.0:
   version "4.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
+  resolved "https://registry.yarnpkg.com/browserify-sign/-/browserify-sign-4.2.1.tgz#eaf4add46dd54be3bb3b36c0cf15abbeba7956c3"
   integrity sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   dependencies:
     bn.js "^5.1.1"
@@ -4492,7 +4492,7 @@ browserslist@^4.12.0:
 
 browserslist@^4.17.5, browserslist@^4.19.1, browserslist@^4.6.6:
   version "4.20.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
   integrity sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
   dependencies:
     caniuse-lite "^1.0.30001317"
@@ -4503,12 +4503,12 @@ browserslist@^4.17.5, browserslist@^4.19.1, browserslist@^4.6.6:
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
 
 buffer-equal@^1.0.0:
@@ -4523,12 +4523,12 @@ buffer-from@^1.0.0:
 
 buffer-xor@^1.0.3:
   version "1.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
+  resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
 buffer@4.9.2:
   version "4.9.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
   dependencies:
     base64-js "^1.0.2"
@@ -4567,7 +4567,7 @@ cache-base@^1.0.1:
 
 cachedir@^2.3.0:
   version "2.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
+  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.3.0.tgz#0c75892a052198f0b21c7c1804d8331edfcae0e8"
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
 
 call-bind@^1.0.0, call-bind@^1.0.2:
@@ -4609,17 +4609,17 @@ camelize@^1.0.0:
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001181:
   version "1.0.30001248"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz"
   integrity sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw==
 
 caniuse-lite@^1.0.30001317:
   version "1.0.30001322"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz#2e4c09d11e1e8f852767dab287069a8d0c29d623"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001322.tgz#2e4c09d11e1e8f852767dab287069a8d0c29d623"
   integrity sha512-neRmrmIrCGuMnxGSoh+x7zYtQFFgnSY2jaomjU56sCkTA6JINqQrxutF459JpWcWRajvoyn95sOXq4Pqrnyjew==
 
 caseless@~0.12.0:
   version "0.12.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
 chalk@^1.0.0:
@@ -4676,17 +4676,17 @@ character-reference-invalid@^1.0.0:
 
 chardet@^0.7.0:
   version "0.7.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 charenc@0.0.2:
   version "0.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
 check-more-types@^2.24.0:
   version "2.24.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
+  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
 
 chokidar@^2.0.0:
@@ -4710,17 +4710,17 @@ chokidar@^2.0.0:
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
 
 ci-info@^3.2.0:
   version "3.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.3.2.tgz#6d2967ffa407466481c6c90b6e16b3098f080128"
   integrity sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
   integrity sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==
   dependencies:
     inherits "^2.0.1"
@@ -4728,7 +4728,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
 
 citation-js@^0.5.0:
   version "0.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/citation-js/-/citation-js-0.5.0.tgz#b98bd7c7d42eb246dcf0bdab5156a5960948b6dc"
+  resolved "https://registry.yarnpkg.com/citation-js/-/citation-js-0.5.0.tgz#b98bd7c7d42eb246dcf0bdab5156a5960948b6dc"
   integrity sha512-jwNAfp8KkUjgS1NChXfjEibPlxdrzwdYliuIAOBsnznZUdWqnGuAFC5gaM4bdhzU1EML9SfF6K9F/ZDy/WtGpA==
   dependencies:
     "@citation-js/cli" "0.5.0"
@@ -4745,7 +4745,7 @@ citation-js@^0.5.0:
 
 citeproc@^2.4.59, citeproc@^2.4.6:
   version "2.4.59"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/citeproc/-/citeproc-2.4.59.tgz#36e1fab8cba4c7f2f88d3f009094b06d4bf08879"
+  resolved "https://registry.yarnpkg.com/citeproc/-/citeproc-2.4.59.tgz#36e1fab8cba4c7f2f88d3f009094b06d4bf08879"
   integrity sha512-BoOk7hu2ORheW2TT//Xj6AFnyP9CuVuQ6THBYTRXO3wEYTMviPbcyXFiZ/tPg5bijvvvVa4gPJRVnipQ0y2aKw==
 
 class-utils@^0.3.5:
@@ -4765,26 +4765,26 @@ clean-stack@^2.0.0:
 
 clear-cut@^2.0.2:
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/clear-cut/-/clear-cut-2.0.2.tgz#082db32ecaa44a358a7b086852fe1d5480bbeed1"
+  resolved "https://registry.yarnpkg.com/clear-cut/-/clear-cut-2.0.2.tgz#082db32ecaa44a358a7b086852fe1d5480bbeed1"
   integrity sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   dependencies:
     restore-cursor "^2.0.0"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
 
 cli-table3@^0.5.1:
   version "0.5.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
   integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
   dependencies:
     object-assign "^4.1.0"
@@ -4794,7 +4794,7 @@ cli-table3@^0.5.1:
 
 cli-table3@~0.6.1:
   version "0.6.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
   integrity sha512-QyavHCaIC80cMivimWu4aWHilIpiDpfm3hGmqAmXVL1UsnbLuBSMd21hTX6VY4ZSDSM73ESLeF8TOYId3rBTbw==
   dependencies:
     string-width "^4.2.0"
@@ -4803,7 +4803,7 @@ cli-table3@~0.6.1:
 
 cli-truncate@^2.1.0:
   version "2.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-2.1.0.tgz#c39e28bf05edcde5be3b98992a22deed5a2b93c7"
   integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
   dependencies:
     slice-ansi "^3.0.0"
@@ -4811,7 +4811,7 @@ cli-truncate@^2.1.0:
 
 cli-width@^2.0.0:
   version "2.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 clipboard@^2.0.0:
@@ -4825,7 +4825,7 @@ clipboard@^2.0.0:
 
 clipboard@^2.0.8:
   version "2.0.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
   integrity sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==
   dependencies:
     good-listener "^1.2.2"
@@ -4945,17 +4945,17 @@ colorette@^1.2.1:
 
 colorette@^2.0.16:
   version "2.0.19"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
@@ -4967,27 +4967,27 @@ commander@^2.20.0:
 
 commander@^5.1.0:
   version "5.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
 commander@^6.2.0:
   version "6.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^7.0.0, commander@^7.2.0:
   version "7.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.0.0:
   version "8.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 common-tags@^1.8.0:
   version "1.8.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
   integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 component-emitter@^1.2.1:
@@ -5054,7 +5054,7 @@ copy-to-clipboard@^3.2.0:
 
 core-js-compat@^3.20.2, core-js-compat@^3.21.0:
   version "3.21.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/core-js-compat/-/core-js-compat-3.21.1.tgz#cac369f67c8d134ff8f9bd1623e3bc2c42068c82"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.21.1.tgz#cac369f67c8d134ff8f9bd1623e3bc2c42068c82"
   integrity sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==
   dependencies:
     browserslist "^4.19.1"
@@ -5083,7 +5083,7 @@ cosmiconfig@^7.0.0:
 
 cosmiconfig@^7.0.1:
   version "7.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
   dependencies:
     "@types/parse-json" "^4.0.0"
@@ -5094,7 +5094,7 @@ cosmiconfig@^7.0.1:
 
 create-ecdh@^4.0.0:
   version "4.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
+  resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
   integrity sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
   dependencies:
     bn.js "^4.1.0"
@@ -5102,7 +5102,7 @@ create-ecdh@^4.0.0:
 
 create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
+  resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
   integrity sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==
   dependencies:
     cipher-base "^1.0.1"
@@ -5113,7 +5113,7 @@ create-hash@^1.1.0, create-hash@^1.1.2, create-hash@^1.2.0:
 
 create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
   version "1.1.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
+  resolved "https://registry.yarnpkg.com/create-hmac/-/create-hmac-1.1.7.tgz#69170c78b3ab957147b2b8b04572e47ead2243ff"
   integrity sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
   dependencies:
     cipher-base "^1.0.3"
@@ -5134,12 +5134,12 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
 
 crypt@0.0.2:
   version "0.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-browserify@^3.12.0:
   version "3.12.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
   integrity sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
   dependencies:
     browserify-cipher "^1.0.0"
@@ -5156,7 +5156,7 @@ crypto-browserify@^3.12.0:
 
 crypto-js@^4.0.0:
   version "4.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
   integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
 
 css-color-keywords@^1.0.0:
@@ -5174,7 +5174,7 @@ css-in-js-utils@^2.0.0:
 
 css-select@^4.1.3:
   version "4.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
   integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
   dependencies:
     boolbase "^1.0.0"
@@ -5202,7 +5202,7 @@ css-tree@^1.1.2:
 
 css-tree@^1.1.3:
   version "1.1.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
   integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
   dependencies:
     mdn-data "2.0.14"
@@ -5210,7 +5210,7 @@ css-tree@^1.1.3:
 
 css-what@^6.0.1:
   version "6.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.0.1.tgz#3be33be55b9f302f710ba3a9c3abc1e2a63fc7eb"
   integrity sha512-z93ZGFLNc6yaoXAmVhqoSIb+BduplteCt1fepvwhBUQK6MNE4g6fgjpuZKJKp0esUe+vXWlIkwZZjNWoOKw0ZA==
 
 cssesc@^3.0.0:
@@ -5237,7 +5237,7 @@ csstype@^3.0.6:
 
 cypress@^10.3.1:
   version "10.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
   integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
   dependencies:
     "@cypress/request" "^2.88.10"
@@ -5293,7 +5293,7 @@ d@1, d@^1.0.1:
 
 dashdash@^1.12.0:
   version "1.14.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
+  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   integrity sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
   dependencies:
     assert-plus "^1.0.0"
@@ -5310,7 +5310,7 @@ dateformat@^2.0.0:
 
 dayjs@^1.10.4:
   version "1.11.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
   integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
 
 debug@^2.2.0, debug@^2.3.3:
@@ -5322,7 +5322,7 @@ debug@^2.2.0, debug@^2.3.3:
 
 debug@^3.1.0:
   version "3.2.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
@@ -5336,7 +5336,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
 
 debug@^4.3.2:
   version "4.3.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
@@ -5426,7 +5426,7 @@ del@^6.0.0:
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 delegate@^3.1.2:
@@ -5436,7 +5436,7 @@ delegate@^3.1.2:
 
 des.js@^1.0.0:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
+  resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
   integrity sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==
   dependencies:
     inherits "^2.0.1"
@@ -5449,17 +5449,17 @@ detect-file@^1.0.0:
 
 detect-libc@^1.0.3:
   version "1.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 diff@^3.5.0:
   version "3.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
+  resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
   integrity sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==
   dependencies:
     bn.js "^4.1.0"
@@ -5480,7 +5480,7 @@ direction@^1.0.3:
 
 dnd-core@12.0.1:
   version "12.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dnd-core/-/dnd-core-12.0.1.tgz#2263391d6de218801770df4d345294a5f1eccc48"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-12.0.1.tgz#2263391d6de218801770df4d345294a5f1eccc48"
   integrity sha512-KzfKXQM9t9uSBO7DFmrILVgXUCShpY3/MbnLPF9/wg1Wcvq2KblbeT72GhjcrplS9cz0DFXilE1NXy43n8plag==
   dependencies:
     "@react-dnd/asap" "^4.0.0"
@@ -5528,7 +5528,7 @@ dom-serializer@0:
 
 dom-serializer@^1.0.1:
   version "1.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
   integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
   dependencies:
     domelementtype "^2.0.1"
@@ -5547,7 +5547,7 @@ domelementtype@^2.0.1:
 
 domelementtype@^2.2.0:
   version "2.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
   integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domhandler@^2.3.0:
@@ -5559,7 +5559,7 @@ domhandler@^2.3.0:
 
 domhandler@^4.2.0, domhandler@^4.2.2, domhandler@^4.3.1:
   version "4.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
@@ -5574,7 +5574,7 @@ domutils@^1.5.1:
 
 domutils@^2.8.0:
   version "2.8.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
   integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
     dom-serializer "^1.0.1"
@@ -5583,12 +5583,12 @@ domutils@^2.8.0:
 
 dotenv-expand@^5.1.0:
   version "5.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
 dotenv@^7.0.0:
   version "7.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-7.0.0.tgz#a2be3cd52736673206e8a85fb5210eea29628e7c"
   integrity sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==
 
 duplexer2@0.0.2:
@@ -5618,7 +5618,7 @@ each-props@^1.3.0:
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
+  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
   integrity sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
   dependencies:
     jsbn "~0.1.0"
@@ -5626,7 +5626,7 @@ ecc-jsbn@~0.1.1:
 
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
   dependencies:
     safe-buffer "^5.0.1"
@@ -5638,12 +5638,12 @@ electron-to-chromium@^1.3.649:
 
 electron-to-chromium@^1.4.84:
   version "1.4.101"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/electron-to-chromium/-/electron-to-chromium-1.4.101.tgz#71f3a10065146d7445ba5d4c06ba2cc063b0817a"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.101.tgz#71f3a10065146d7445ba5d4c06ba2cc063b0817a"
   integrity sha512-XJH+XmJjACx1S7ASl/b//KePcda5ocPnFH2jErztXcIS8LpP0SE6rX8ZxiY5/RaDPnaF1rj0fPaHfppzb0e2Aw==
 
 elliptic@^6.5.3:
   version "6.5.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
   dependencies:
     bn.js "^4.11.9"
@@ -5685,12 +5685,12 @@ entities@^2.0.0:
 
 entities@^3.0.1:
   version "3.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 entities@~2.1.0:
   version "2.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
   integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 error-ex@^1.2.0, error-ex@^1.3.1:
@@ -5747,7 +5747,7 @@ es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50:
 
 es5-ext@~0.10.14:
   version "0.10.62"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.62.tgz#5e6adc19a6da524bf3d1e02bbc8960e5eb49a9a5"
   integrity sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==
   dependencies:
     es6-iterator "^2.0.3"
@@ -5810,7 +5810,7 @@ eslint-config-react-app@^6.0.0:
 
 eslint-plugin-cypress@^2.12.1:
   version "2.12.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
   integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
   dependencies:
     globals "^11.12.0"
@@ -5987,7 +5987,7 @@ esutils@^2.0.2:
 
 event-emitter@^0.3.5:
   version "0.3.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
   dependencies:
     d "1"
@@ -5995,17 +5995,17 @@ event-emitter@^0.3.5:
 
 eventemitter2@^6.4.3:
   version "6.4.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/eventemitter2/-/eventemitter2-6.4.6.tgz#92d56569cc147a4d9b9da9e942e89b20ce236b0a"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.6.tgz#92d56569cc147a4d9b9da9e942e89b20ce236b0a"
   integrity sha512-OHqo4wbHX5VbvlbB6o6eDwhYmiTjrpWACjF8Pmof/GTD6rdBNdZFNck3xlhqOiQFGCOoq3uzHvA0cQpFHIGVAQ==
 
 events@^3.1.0:
   version "3.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
   integrity sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==
   dependencies:
     md5.js "^1.3.4"
@@ -6013,7 +6013,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
 
 execa@4.1.0:
   version "4.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
   dependencies:
     cross-spawn "^7.0.0"
@@ -6035,7 +6035,7 @@ execall@^2.0.0:
 
 executable@^4.1.1:
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
+  resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
   integrity sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==
   dependencies:
     pify "^2.2.0"
@@ -6089,7 +6089,7 @@ extend@^3.0.0, extend@~3.0.2:
 
 external-editor@^3.0.3:
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
   integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
   dependencies:
     chardet "^0.7.0"
@@ -6112,7 +6112,7 @@ extglob@^2.0.4:
 
 extract-zip@2.0.1:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
   dependencies:
     debug "^4.1.1"
@@ -6123,12 +6123,12 @@ extract-zip@2.0.1:
 
 extsprintf@1.3.0:
   version "1.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
   integrity sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
 
 extsprintf@^1.2.0:
   version "1.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fancy-log@^1.1.0, fancy-log@^1.3.2, fancy-log@^1.3.3:
@@ -6143,7 +6143,7 @@ fancy-log@^1.1.0, fancy-log@^1.3.2, fancy-log@^1.3.3:
 
 fast-base64-decode@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
   integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
@@ -6190,7 +6190,7 @@ fast-shallow-equal@^1.0.0:
 
 fast-xml-parser@^3.16.0:
   version "3.19.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
   integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
 fastest-levenshtein@^1.0.12:
@@ -6212,26 +6212,26 @@ fastq@^1.6.0:
 
 fclone@^1.0.11:
   version "1.0.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
+  resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
   integrity sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=
 
 fd-slicer@~1.1.0:
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
+  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
   integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
   dependencies:
     pend "~1.2.0"
 
 figures@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
 
 figures@^3.2.0:
   version "3.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
@@ -6245,7 +6245,7 @@ file-entry-cache@^6.0.0:
 
 file-saver@^2.0.5:
   version "2.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
   integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-uri-to-path@1.0.0:
@@ -6367,12 +6367,12 @@ for-own@^1.0.0:
 
 forever-agent@~0.6.1:
   version "0.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
 form-data@~2.3.2:
   version "2.3.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   dependencies:
     asynckit "^0.4.0"
@@ -6401,7 +6401,7 @@ fragment-cache@^0.2.1:
 
 fs-extra@^10.0.1:
   version "10.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.1.tgz#27de43b4320e833f6867cc044bfce29fdf0ef3b8"
   integrity sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==
   dependencies:
     graceful-fs "^4.2.0"
@@ -6410,7 +6410,7 @@ fs-extra@^10.0.1:
 
 fs-extra@^9.1.0:
   version "9.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
   dependencies:
     at-least-node "^1.0.0"
@@ -6441,7 +6441,7 @@ fsevents@^1.2.7:
 
 fstream@>=1.0.12:
   version "1.0.12"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
   dependencies:
     graceful-fs "^4.1.2"
@@ -6461,7 +6461,7 @@ functional-red-black-tree@^1.0.1:
 
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-caller-file@^1.0.1:
@@ -6480,7 +6480,7 @@ get-intrinsic@^1.0.1, get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@
 
 get-port@^4.2.0:
   version "4.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.2.0.tgz#e37368b1e863b7629c43c5a323625f95cf24b119"
   integrity sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==
 
 get-stdin@^8.0.0:
@@ -6490,7 +6490,7 @@ get-stdin@^8.0.0:
 
 get-stream@^5.0.0, get-stream@^5.1.0:
   version "5.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
@@ -6502,14 +6502,14 @@ get-value@^2.0.3, get-value@^2.0.6:
 
 getos@^3.2.1:
   version "3.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/getos/-/getos-3.2.1.tgz#0134d1f4e00eb46144c5a9c0ac4dc087cbb27dc5"
+  resolved "https://registry.yarnpkg.com/getos/-/getos-3.2.1.tgz#0134d1f4e00eb46144c5a9c0ac4dc087cbb27dc5"
   integrity sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==
   dependencies:
     async "^3.2.0"
 
 getpass@^0.1.1:
   version "0.1.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
+  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
@@ -6572,7 +6572,7 @@ glob@^7.1.1, glob@^7.1.3:
 
 global-dirs@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.0.tgz#70a76fe84ea315ab37b1f5576cbde7d48ef72686"
   integrity sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==
   dependencies:
     ini "2.0.0"
@@ -6627,7 +6627,7 @@ globals@^12.1.0:
 
 globals@^13.2.0:
   version "13.13.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/globals/-/globals-13.13.0.tgz#ac32261060d8070e2719dd6998406e27d2b5727b"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.13.0.tgz#ac32261060d8070e2719dd6998406e27d2b5727b"
   integrity sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==
   dependencies:
     type-fest "^0.20.2"
@@ -6677,12 +6677,12 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6,
 
 graceful-fs@^4.2.0:
   version "4.2.9"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
 graphql@14.0.0:
   version "14.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/graphql/-/graphql-14.0.0.tgz#4ee771c5266d08cb75df2d3ac41e8dd51ce3d599"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.0.tgz#4ee771c5266d08cb75df2d3ac41e8dd51ce3d599"
   integrity sha512-HGVcnO6B25YZcSt6ZsH6/N+XkYuPA7yMqJmlJ4JWxWlS4Tr8SHI56R1Ocs8Eor7V7joEZPRXPDH8RRdll1w44Q==
   dependencies:
     iterall "^1.2.2"
@@ -6775,12 +6775,12 @@ gulplog@^1.0.0:
 
 har-schema@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
   version "5.1.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
   integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
     ajv "^6.12.3"
@@ -6865,7 +6865,7 @@ has@^1.0.3:
 
 hash-base@^3.0.0:
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
+  resolved "https://registry.yarnpkg.com/hash-base/-/hash-base-3.1.0.tgz#55c381d9e06e1d2997a883b4a3fddfe7f0d3af33"
   integrity sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==
   dependencies:
     inherits "^2.0.4"
@@ -6874,7 +6874,7 @@ hash-base@^3.0.0:
 
 hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   dependencies:
     inherits "^2.0.3"
@@ -6894,7 +6894,7 @@ history@^4.10.0, history@^4.9.0:
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
+  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
   integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
   dependencies:
     hash.js "^1.0.3"
@@ -6934,7 +6934,7 @@ html-tags@^3.1.0:
 
 htmlnano@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/htmlnano/-/htmlnano-2.0.0.tgz#07376faa064f7e1e832dfd91e1a9f606b0bc9b78"
+  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-2.0.0.tgz#07376faa064f7e1e832dfd91e1a9f606b0bc9b78"
   integrity sha512-thKQfhcp2xgtsWNE27A2bliEeqVL5xjAgGn0wajyttvFFsvFWWah1ntV9aEX61gz0T6MBQ5xK/1lXuEumhJTcg==
   dependencies:
     cosmiconfig "^7.0.1"
@@ -6955,7 +6955,7 @@ htmlparser2@^3.10.0:
 
 htmlparser2@^7.1.1:
   version "7.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
   integrity sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==
   dependencies:
     domelementtype "^2.0.1"
@@ -6965,7 +6965,7 @@ htmlparser2@^7.1.1:
 
 http-signature@~1.2.0:
   version "1.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
   integrity sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
   dependencies:
     assert-plus "^1.0.0"
@@ -6974,7 +6974,7 @@ http-signature@~1.2.0:
 
 http-signature@~1.3.6:
   version "1.3.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.3.6.tgz#cb6fbfdf86d1c974f343be94e87f7fc128662cf9"
   integrity sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==
   dependencies:
     assert-plus "^1.0.0"
@@ -6983,7 +6983,7 @@ http-signature@~1.3.6:
 
 human-signals@^1.1.1:
   version "1.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
 humps@^2.0.1:
@@ -7005,7 +7005,7 @@ iconv-lite@^0.4.24:
 
 idb@5.0.6:
   version "5.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/idb/-/idb-5.0.6.tgz#8c94624f5a8a026abe3bef3c7166a5febd1cadc1"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-5.0.6.tgz#8c94624f5a8a026abe3bef3c7166a5febd1cadc1"
   integrity sha512-/PFvOWPzRcEPmlDt5jEvzVZVs0wyd/EvGvkDIcbBpGuMMLQKrTPG0TxvE2UJtgZtCQCmOtM2QD7yQJBVEjKGOw==
 
 ieee754@^1.1.13, ieee754@^1.1.4:
@@ -7030,7 +7030,7 @@ image-extensions@^1.1.0:
 
 immer@8.0.1:
   version "8.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 immer@^5.0.0:
@@ -7081,7 +7081,7 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, 
 
 ini@2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
 
 ini@^1.3.4, ini@^1.3.5:
@@ -7098,7 +7098,7 @@ inline-style-prefixer@^6.0.0:
 
 inquirer@^6.2.2:
   version "6.5.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
   integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
   dependencies:
     ansi-escapes "^3.2.0"
@@ -7198,7 +7198,7 @@ is-callable@^1.1.4, is-callable@^1.2.2:
 
 is-ci@^3.0.0:
   version "3.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
@@ -7212,7 +7212,7 @@ is-core-module@^2.2.0:
 
 is-core-module@^2.8.1:
   version "2.8.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
@@ -7261,7 +7261,7 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
 
 is-domain@0.0.1:
   version "0.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-domain/-/is-domain-0.0.1.tgz#7ffb288d5cced6b07c4f2df91c9be9153511348e"
+  resolved "https://registry.yarnpkg.com/is-domain/-/is-domain-0.0.1.tgz#7ffb288d5cced6b07c4f2df91c9be9153511348e"
   integrity sha1-f/sojVzO1rB8Ty35HJvpFTURNI4=
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
@@ -7290,7 +7290,7 @@ is-fullwidth-code-point@^1.0.0:
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-fullwidth-code-point@^3.0.0:
@@ -7329,7 +7329,7 @@ is-hotkey@^0.2.0:
 
 is-installed-globally@~0.4.0:
   version "0.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
   integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
   dependencies:
     global-dirs "^3.0.0"
@@ -7337,7 +7337,7 @@ is-installed-globally@~0.4.0:
 
 is-json@^2.0.1:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
+  resolved "https://registry.yarnpkg.com/is-json/-/is-json-2.0.1.tgz#6be166d144828a131d686891b983df62c39491ff"
   integrity sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8=
 
 is-negated-glob@^1.0.0:
@@ -7352,7 +7352,7 @@ is-negative-zero@^2.0.1:
 
 is-number-like@^1.0.3:
   version "1.0.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-number-like/-/is-number-like-1.0.8.tgz#2e129620b50891042e44e9bbbb30593e75cfbbe3"
+  resolved "https://registry.yarnpkg.com/is-number-like/-/is-number-like-1.0.8.tgz#2e129620b50891042e44e9bbbb30593e75cfbbe3"
   integrity sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==
   dependencies:
     lodash.isfinite "^3.3.2"
@@ -7428,7 +7428,7 @@ is-relative@^1.0.0:
 
 is-stream@^2.0.0:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
 is-string@^1.0.5:
@@ -7499,7 +7499,7 @@ isobject@^3.0.0, isobject@^3.0.1:
 
 isomorphic-fetch@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
   integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
   dependencies:
     node-fetch "^2.6.1"
@@ -7507,7 +7507,7 @@ isomorphic-fetch@^3.0.0:
 
 isomorphic-unfetch@^3.0.0:
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
   integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
   dependencies:
     node-fetch "^2.6.1"
@@ -7515,12 +7515,12 @@ isomorphic-unfetch@^3.0.0:
 
 isstream@~0.1.2:
   version "0.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 iterall@^1.2.2:
   version "1.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 js-cookie@^2.2.1:
@@ -7543,7 +7543,7 @@ js-yaml@^3.13.1, js-yaml@^3.14.1:
 
 jsbn@~0.1.0:
   version "0.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsesc@^2.5.1:
@@ -7573,17 +7573,17 @@ json-schema-traverse@^1.0.0:
 
 json-schema@0.2.3:
   version "0.2.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
 json-schema@0.4.0:
   version "0.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-source-map@^0.6.1:
   version "0.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
+  resolved "https://registry.yarnpkg.com/json-source-map/-/json-source-map-0.6.1.tgz#e0b1f6f4ce13a9ad57e2ae165a24d06e62c79a0f"
   integrity sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==
 
 json-stable-stringify-without-jsonify@^1.0.1:
@@ -7593,7 +7593,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
 
 json-stringify-safe@~5.0.1:
   version "5.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^2.1.2:
@@ -7605,12 +7605,12 @@ json5@^2.1.2:
 
 json5@^2.2.0:
   version "2.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
   integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonfile@^6.0.1:
   version "6.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
   integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
   dependencies:
     universalify "^2.0.0"
@@ -7627,7 +7627,7 @@ jsonlint@^1.6.3:
 
 jsonwebtoken@^8.5.1:
   version "8.5.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
   dependencies:
     jws "^3.2.2"
@@ -7643,7 +7643,7 @@ jsonwebtoken@^8.5.1:
 
 jsprim@^1.2.2:
   version "1.4.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   dependencies:
     assert-plus "1.0.0"
@@ -7653,7 +7653,7 @@ jsprim@^1.2.2:
 
 jsprim@^2.0.2:
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
+  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-2.0.2.tgz#77ca23dbcd4135cd364800d22ff82c2185803d4d"
   integrity sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==
   dependencies:
     assert-plus "1.0.0"
@@ -7676,12 +7676,12 @@ just-debounce@^1.0.0:
 
 just-extend@^4.0.2:
   version "4.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
 jwa@^1.4.1:
   version "1.4.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
   integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
   dependencies:
     buffer-equal-constant-time "1.0.1"
@@ -7690,7 +7690,7 @@ jwa@^1.4.1:
 
 jws@^3.2.2:
   version "3.2.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
   integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
   dependencies:
     jwa "^1.4.1"
@@ -7698,7 +7698,7 @@ jws@^3.2.2:
 
 katex@^0.15.3:
   version "0.15.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/katex/-/katex-0.15.3.tgz#08781a7ed26800b20380d959d1ffcd62bca0ec14"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.15.3.tgz#08781a7ed26800b20380d959d1ffcd62bca0ec14"
   integrity sha512-Al6V7RJsmjklT9QItyHWGaQCt+NYTle1bZwB1e9MR/tLoIT1MXaHy9UpfGSB7eaqDgjjqqRxQOaQGrALCrEyBQ==
   dependencies:
     commander "^8.0.0"
@@ -7749,7 +7749,7 @@ last-run@^1.1.0:
 
 lazy-ass@^1.6.0:
   version "1.6.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
+  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
   integrity sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
 
 lazystream@^1.0.0:
@@ -7802,14 +7802,14 @@ lines-and-columns@^1.1.6:
 
 linkify-it@^3.0.1:
   version "3.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
   integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
   dependencies:
     uc.micro "^1.0.1"
 
 listr2@^3.8.3:
   version "3.14.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/listr2/-/listr2-3.14.0.tgz#23101cc62e1375fd5836b248276d1d2b51fdbe9e"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.14.0.tgz#23101cc62e1375fd5836b248276d1d2b51fdbe9e"
   integrity sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==
   dependencies:
     cli-truncate "^2.1.0"
@@ -7823,7 +7823,7 @@ listr2@^3.8.3:
 
 lmdb@2.2.4:
   version "2.2.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lmdb/-/lmdb-2.2.4.tgz#6494d5a1d1db152e0be759edcfa06893e4cbdb53"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.4.tgz#6494d5a1d1db152e0be759edcfa06893e4cbdb53"
   integrity sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==
   dependencies:
     msgpackr "^1.5.4"
@@ -7929,7 +7929,7 @@ lodash.get@^4.4.2:
 
 lodash.includes@^4.3.0:
   version "4.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
   integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
 
 lodash.isarguments@^3.0.0:
@@ -7944,37 +7944,37 @@ lodash.isarray@^3.0.0:
 
 lodash.isboolean@^3.0.3:
   version "3.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
   integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
 
 lodash.isfinite@^3.3.2:
   version "3.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
+  resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
   integrity sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=
 
 lodash.isinteger@^4.0.4:
   version "4.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
   integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
 
 lodash.isnumber@^3.0.3:
   version "3.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
   integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
   integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.keys@^3.0.0:
@@ -7988,7 +7988,7 @@ lodash.keys@^3.0.0:
 
 lodash.once@^4.0.0, lodash.once@^4.1.1:
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.restparam@^3.0.0:
@@ -7998,7 +7998,7 @@ lodash.restparam@^3.0.0:
 
 lodash.set@^4.3.2:
   version "4.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.template@^3.0.0:
@@ -8048,7 +8048,7 @@ log-symbols@^4.0.0:
 
 log-update@^4.0.0:
   version "4.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
   integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
   dependencies:
     ansi-escapes "^4.3.0"
@@ -8058,12 +8058,12 @@ log-update@^4.0.0:
 
 lolex@^4.2.0:
   version "4.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
   integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 lolex@^5.0.1:
   version "5.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
   integrity sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
@@ -8118,17 +8118,17 @@ map-visit@^1.0.0:
 
 markdown-it-anchor@^8.4.1:
   version "8.4.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz#29e560593f5edb80b25fdab8b23f93ef8a91b31e"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz#29e560593f5edb80b25fdab8b23f93ef8a91b31e"
   integrity sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==
 
 markdown-it-table-of-contents@^0.6.0:
   version "0.6.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz#7c9e8d619fb12f88c9fb05a7b32b2fe932b9c541"
+  resolved "https://registry.yarnpkg.com/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.6.0.tgz#7c9e8d619fb12f88c9fb05a7b32b2fe932b9c541"
   integrity sha512-jHvEjZVEibyW97zEYg19mZCIXO16lHbvRaPDkEuOfMPBmzlI7cYczMZLMfUvwkhdOVQpIxu3gx6mgaw46KsNsQ==
 
 markdown-it@^12.0.6:
   version "12.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/markdown-it/-/markdown-it-12.0.6.tgz#adcc8e5fe020af292ccbdf161fe84f1961516138"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.6.tgz#adcc8e5fe020af292ccbdf161fe84f1961516138"
   integrity sha512-qv3sVLl4lMT96LLtR7xeRJX11OUFjsaD5oVat2/SNBIb21bJXwal2+SklcRbTwGwqWpWH/HRtYavOoJE+seL8w==
   dependencies:
     argparse "^2.0.1"
@@ -8159,7 +8159,7 @@ mathml-tag-names@^2.1.3:
 
 md5.js@^1.3.4:
   version "1.3.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
+  resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
   integrity sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==
   dependencies:
     hash-base "^3.0.0"
@@ -8168,7 +8168,7 @@ md5.js@^1.3.4:
 
 md5@^2.3.0:
   version "2.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
   integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
   dependencies:
     charenc "0.0.2"
@@ -8210,12 +8210,12 @@ mdn-data@2.0.14:
 
 mdurl@^1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 memoize-one@^5.0.0:
   version "5.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
 
 meow@^9.0.0:
@@ -8238,7 +8238,7 @@ meow@^9.0.0:
 
 merge-stream@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
 merge2@^1.3.0:
@@ -8283,7 +8283,7 @@ micromatch@^4.0.2:
 
 miller-rabin@^4.0.0:
   version "4.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
+  resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
   integrity sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==
   dependencies:
     bn.js "^4.0.0"
@@ -8291,24 +8291,24 @@ miller-rabin@^4.0.0:
 
 mime-db@1.48.0:
   version "1.48.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
   integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
   version "2.1.31"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
   integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
     mime-db "1.48.0"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
 mimic-fn@^2.1.0:
   version "2.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 min-indent@^1.0.0:
@@ -8326,12 +8326,12 @@ mini-create-react-context@^0.4.0:
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
+  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
 minimatch@^3.0.0, minimatch@^3.0.4:
@@ -8352,7 +8352,7 @@ minimist-options@4.1.0:
 
 minimist@1.2.3:
   version "1.2.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
   integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 minimist@^1.1.0, minimist@^1.2.5:
@@ -8362,7 +8362,7 @@ minimist@^1.1.0, minimist@^1.2.5:
 
 minimist@^1.2.6:
   version "1.2.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mixin-deep@^1.2.0:
@@ -8382,12 +8382,12 @@ mixin-deep@^1.2.0:
 
 moniker@0.1.2:
   version "0.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/moniker/-/moniker-0.1.2.tgz#872dfba575dcea8fa04a5135b13d5f24beccc97e"
+  resolved "https://registry.yarnpkg.com/moniker/-/moniker-0.1.2.tgz#872dfba575dcea8fa04a5135b13d5f24beccc97e"
   integrity sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=
 
 moo@^0.5.1:
   version "0.5.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
 ms@2.0.0:
@@ -8402,12 +8402,12 @@ ms@2.1.2:
 
 ms@^2.1.1:
   version "2.1.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 msgpackr-extract@^1.0.14:
   version "1.0.16"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/msgpackr-extract/-/msgpackr-extract-1.0.16.tgz#701c4f6e6f25c100ae84557092274e8fffeefe45"
+  resolved "https://registry.yarnpkg.com/msgpackr-extract/-/msgpackr-extract-1.0.16.tgz#701c4f6e6f25c100ae84557092274e8fffeefe45"
   integrity sha512-fxdRfQUxPrL/TizyfYfMn09dK58e+d65bRD/fcaVH4052vj30QOzzqxcQIS7B0NsqlypEQ/6Du3QmP2DhWFfCA==
   dependencies:
     nan "^2.14.2"
@@ -8415,7 +8415,7 @@ msgpackr-extract@^1.0.14:
 
 msgpackr@^1.5.4:
   version "1.5.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/msgpackr/-/msgpackr-1.5.5.tgz#c0562abc2951d7e29f75d77a8656b01f103a042c"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.5.5.tgz#c0562abc2951d7e29f75d77a8656b01f103a042c"
   integrity sha512-JG0V47xRIQ9pyUnx6Hb4+3TrQoia2nA3UIdmyTldhxaxtKFkekkKpUW/N6fwHwod9o4BGuJGtouxOk+yCP5PEA==
   optionalDependencies:
     msgpackr-extract "^1.0.14"
@@ -8434,12 +8434,12 @@ mute-stdout@^1.0.0:
 
 mute-stream@0.0.7:
   version "0.0.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 mute-stream@~0.0.4:
   version "0.0.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1:
@@ -8449,7 +8449,7 @@ nan@^2.12.1:
 
 nan@^2.14.2:
   version "2.15.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
 nano-css@^5.2.1:
@@ -8490,12 +8490,12 @@ natural-compare@^1.4.0:
 
 netrc@0.1.4:
   version "0.1.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
   integrity sha1-a+lPysqNd63gqWcNxGCRTJRHJEQ=
 
 next-tick@^1.1.0:
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 next-tick@~1.0.0:
@@ -8505,7 +8505,7 @@ next-tick@~1.0.0:
 
 nise@^1.5.2:
   version "1.5.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.3.tgz#9d2cfe37d44f57317766c6e9408a359c5d3ac1f7"
   integrity sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
   dependencies:
     "@sinonjs/formatio" "^3.2.1"
@@ -8516,17 +8516,17 @@ nise@^1.5.2:
 
 node-addon-api@^3.2.1:
   version "3.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
 node-fetch@^2.6.1:
   version "2.6.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp-build@^4.2.3, node-gyp-build@^4.3.0:
   version "4.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-releases@^1.1.70:
@@ -8536,7 +8536,7 @@ node-releases@^1.1.70:
 
 node-releases@^2.0.2:
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
 nomnom@^1.5.x:
@@ -8598,21 +8598,21 @@ now-and-later@^2.0.0:
 
 npm-run-path@^4.0.0:
   version "4.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
 
 nth-check@^2.0.1:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
   integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
   dependencies:
     boolbase "^1.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
+  resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
 num2fraction@^1.2.2:
@@ -8627,7 +8627,7 @@ number-is-nan@^1.0.0:
 
 oauth-sign@~0.9.0:
   version "0.9.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
 object-assign@^3.0.0:
@@ -8768,14 +8768,14 @@ once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
 
 onetime@^2.0.0:
   version "2.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
   version "5.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
@@ -8794,7 +8794,7 @@ optionator@^0.9.1:
 
 ordered-binary@^1.2.4:
   version "1.2.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ordered-binary/-/ordered-binary-1.2.4.tgz#51d3a03af078a0bdba6c7bc8f4fedd1f5d45d83e"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.2.4.tgz#51d3a03af078a0bdba6c7bc8f4fedd1f5d45d83e"
   integrity sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==
 
 ordered-read-streams@^1.0.0:
@@ -8813,12 +8813,12 @@ os-locale@^1.4.0:
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
 
 ospath@^1.2.2:
   version "1.2.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
+  resolved "https://registry.yarnpkg.com/ospath/-/ospath-1.2.2.tgz#1276639774a3f8ef2572f7fe4280e0ea4550c07b"
   integrity sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
 
 p-limit@^2.2.0:
@@ -8849,7 +8849,7 @@ p-try@^2.0.0:
 
 pagedjs@^0.4.0:
   version "0.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/pagedjs/-/pagedjs-0.4.0.tgz#cfdba58bd04f32409c20084007d19fca4b31caaf"
+  resolved "https://registry.yarnpkg.com/pagedjs/-/pagedjs-0.4.0.tgz#cfdba58bd04f32409c20084007d19fca4b31caaf"
   integrity sha512-AkcG5W/O2sB/uVtfiIvl+ESyalHjecDLiOy1zJVOJIeUBRz+theiL2GHyeMTkgQHs76CGrt9w8vzsoaVKsC0Lw==
   dependencies:
     "@babel/polyfill" "^7.10.1"
@@ -8860,12 +8860,12 @@ pagedjs@^0.4.0:
 
 paho-mqtt@^1.1.0:
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/paho-mqtt/-/paho-mqtt-1.1.0.tgz#8c10e29eb162e966fb15188d965c3dce505de9d9"
+  resolved "https://registry.yarnpkg.com/paho-mqtt/-/paho-mqtt-1.1.0.tgz#8c10e29eb162e966fb15188d965c3dce505de9d9"
   integrity sha512-KPbL9KAB0ASvhSDbOrZBaccXS+/s7/LIofbPyERww8hM5Ko71GUJQ6Nmg0BWqj8phAIT8zdf/Sd/RftHU9i2HA==
 
 parcel@^2.4.0:
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/parcel/-/parcel-2.4.0.tgz#9ce7ecee5e24ffe630e14d50801e26de334e89c1"
+  resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.4.0.tgz#9ce7ecee5e24ffe630e14d50801e26de334e89c1"
   integrity sha512-dPWpu4RnxG9HqiLvaF8COEWEnT/KrigrC6PyPaQ0zEgpBfp7/jzXZFBVaZk2N+lpvrbNEYMjN9bv5UQGJJszIw==
   dependencies:
     "@parcel/config-default" "2.4.0"
@@ -8892,7 +8892,7 @@ parent-module@^1.0.0:
 
 parse-asn1@^5.0.0, parse-asn1@^5.1.5:
   version "5.1.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
+  resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.6.tgz#385080a3ec13cb62a62d39409cb3e88844cdaed4"
   integrity sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==
   dependencies:
     asn1.js "^5.2.0"
@@ -8988,7 +8988,7 @@ path-parse@^1.0.6:
 
 path-parse@^1.0.7:
   version "1.0.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-root-regex@^0.1.0:
@@ -9026,7 +9026,7 @@ path-type@^4.0.0:
 
 pbkdf2@^3.0.3:
   version "3.1.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
@@ -9037,7 +9037,7 @@ pbkdf2@^3.0.3:
 
 pend@~1.2.0:
   version "1.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
 performance-now@^2.1.0:
@@ -9047,7 +9047,7 @@ performance-now@^2.1.0:
 
 picocolors@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.5, picomatch@^2.2.1:
@@ -9103,7 +9103,7 @@ popper.js@^1.11.1:
 
 portscanner@^2.2.0:
   version "2.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/portscanner/-/portscanner-2.2.0.tgz#6059189b3efa0965c9d96a56b958eb9508411cf1"
+  resolved "https://registry.yarnpkg.com/portscanner/-/portscanner-2.2.0.tgz#6059189b3efa0965c9d96a56b958eb9508411cf1"
   integrity sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==
   dependencies:
     async "^2.6.0"
@@ -9182,7 +9182,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
 
 postcss-value-parser@^4.2.0:
   version "4.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
@@ -9196,7 +9196,7 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.
 
 posthtml-expressions@^1.9.0:
   version "1.9.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml-expressions/-/posthtml-expressions-1.9.0.tgz#0b00e0e557392f66eb6b88d89cd090789eadd78c"
+  resolved "https://registry.yarnpkg.com/posthtml-expressions/-/posthtml-expressions-1.9.0.tgz#0b00e0e557392f66eb6b88d89cd090789eadd78c"
   integrity sha512-jf4BsY2Pw6AoBFQTklOkf+dDhq+kO+R80Dj/plPY/IpZ6sXondzp1O55wJiQK2vIUL4XSAqKdG97wE/j8EH2og==
   dependencies:
     fclone "^1.0.11"
@@ -9206,33 +9206,33 @@ posthtml-expressions@^1.9.0:
 
 posthtml-match-helper@^1.0.1:
   version "1.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml-match-helper/-/posthtml-match-helper-1.0.1.tgz#451253de8e5844a348e963ad5edd7769eb129513"
+  resolved "https://registry.yarnpkg.com/posthtml-match-helper/-/posthtml-match-helper-1.0.1.tgz#451253de8e5844a348e963ad5edd7769eb129513"
   integrity sha1-RRJT3o5YRKNI6WOtXt13aesSlRM=
 
 posthtml-parser@^0.10.0, posthtml-parser@^0.10.1:
   version "0.10.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml-parser/-/posthtml-parser-0.10.2.tgz#df364d7b179f2a6bf0466b56be7b98fd4e97c573"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.10.2.tgz#df364d7b179f2a6bf0466b56be7b98fd4e97c573"
   integrity sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==
   dependencies:
     htmlparser2 "^7.1.1"
 
 posthtml-parser@^0.11.0:
   version "0.11.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml-parser/-/posthtml-parser-0.11.0.tgz#25d1c7bf811ea83559bc4c21c189a29747a24b7a"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.11.0.tgz#25d1c7bf811ea83559bc4c21c189a29747a24b7a"
   integrity sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==
   dependencies:
     htmlparser2 "^7.1.1"
 
 posthtml-render@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml-render/-/posthtml-render-3.0.0.tgz#97be44931496f495b4f07b99e903cc70ad6a3205"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-3.0.0.tgz#97be44931496f495b4f07b99e903cc70ad6a3205"
   integrity sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==
   dependencies:
     is-json "^2.0.1"
 
 posthtml@^0.16.4, posthtml@^0.16.5:
   version "0.16.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/posthtml/-/posthtml-0.16.6.tgz#e2fc407f67a64d2fa3567afe770409ffdadafe59"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.16.6.tgz#e2fc407f67a64d2fa3567afe770409ffdadafe59"
   integrity sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==
   dependencies:
     posthtml-parser "^0.11.0"
@@ -9262,7 +9262,7 @@ prettier@^2.2.1:
 
 pretty-bytes@^5.6.0:
   version "5.6.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
 pretty-hrtime@^1.0.0:
@@ -9284,12 +9284,12 @@ process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
 
 process@^0.11.10:
   version "0.11.10"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
 progress@1.1.8:
   version "1.1.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
 progress@^2.0.0:
@@ -9308,7 +9308,7 @@ prop-types@>=15.7.2, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0
 
 prop-types@^15.8.1:
   version "15.8.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
   dependencies:
     loose-envify "^1.4.0"
@@ -9317,17 +9317,17 @@ prop-types@^15.8.1:
 
 proxy-from-env@1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 psl@^1.1.28:
   version "1.8.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
+  resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
   integrity sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   dependencies:
     bn.js "^4.1.0"
@@ -9347,7 +9347,7 @@ pump@^2.0.0:
 
 pump@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
   integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
   dependencies:
     end-of-stream "^1.1.0"
@@ -9374,12 +9374,12 @@ punycode@^2.1.0, punycode@^2.1.1:
 
 qr.js@0.0.0:
   version "0.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
   integrity sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8=
 
 qs-state-hook@^1.0.3:
   version "1.0.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/qs-state-hook/-/qs-state-hook-1.0.3.tgz#610cebcb13d613e106d448b51942a97473102183"
+  resolved "https://registry.yarnpkg.com/qs-state-hook/-/qs-state-hook-1.0.3.tgz#610cebcb13d613e106d448b51942a97473102183"
   integrity sha512-ceBFZOllGSXqrVZv6532a3Av2uzEmcFUAfc5VTd+aKUlKLtoCv0a+XXhErpzX/PuU6zRxUyE2sks2TxpmOUC4g==
   dependencies:
     lodash.debounce "^4.0.8"
@@ -9394,12 +9394,12 @@ qs@^6.10.1, qs@^6.9.6:
 
 qs@~6.5.2:
   version "6.5.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 querystring-es3@^0.2.1:
   version "0.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
 
 querystring@0.2.0:
@@ -9426,14 +9426,14 @@ raf@^3.1.0:
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
 
 randomfill@^1.0.3:
   version "1.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
+  resolved "https://registry.yarnpkg.com/randomfill/-/randomfill-1.0.4.tgz#c92196fc86ab42be983f1bf31778224931d61458"
   integrity sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==
   dependencies:
     randombytes "^2.0.5"
@@ -9455,14 +9455,14 @@ react-custom-scrollbars@^4.2.1:
 
 react-dnd-html5-backend@^12.1.1:
   version "12.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-dnd-html5-backend/-/react-dnd-html5-backend-12.1.1.tgz#73aa9043f5a2da5b192503593d620d30c0bd7348"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-12.1.1.tgz#73aa9043f5a2da5b192503593d620d30c0bd7348"
   integrity sha512-cQZgfuSGQEwHdvdoPtfUOvcrS8rye/V0hU046LjY/BLSgcrdjtQVviE2d/81QQaeJpvK00JizctsZqVY7IvHgA==
   dependencies:
     dnd-core "12.0.1"
 
 react-dnd@^13.1.1:
   version "13.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-dnd/-/react-dnd-13.1.1.tgz#ea6d3f15cccf542a3ebfb978c097b2e3b1d1c962"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-13.1.1.tgz#ea6d3f15cccf542a3ebfb978c097b2e3b1d1c962"
   integrity sha512-oxQW8846omV1l3Pm2zY/atvNxryx+blW1rxnSmoGvFMgmxXpOHulaXrlXgxRH+OLRvLt2cfVTSxZ4ykbzBypaw==
   dependencies:
     "@react-dnd/invariant" "^2.0.0"
@@ -9491,7 +9491,7 @@ react-fast-compare@^3.1.1:
 
 react-ga@^3.3.0:
   version "3.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.0.tgz#c91f407198adcb3b49e2bc5c12b3fe460039b3ca"
   integrity sha512-o8RScHj6Lb8cwy3GMrVH6NJvL+y0zpJvKtc0+wmH7Bt23rszJmnqEQxRbyrqUzk9DTJIHoP42bfO5rswC9SWBQ==
 
 react-helmet@^6.1.0:
@@ -9506,7 +9506,7 @@ react-helmet@^6.1.0:
 
 react-input-autosize@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
   integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
@@ -9525,19 +9525,19 @@ react-katex@^2.0.2:
 
 react-native-get-random-values@^1.4.0:
   version "1.7.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-native-get-random-values/-/react-native-get-random-values-1.7.0.tgz#86d9d1960828b606392dba4540bf760605448530"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.7.0.tgz#86d9d1960828b606392dba4540bf760605448530"
   integrity sha512-zDhmpWUekGRFb9I+MQkxllHcqXN9HBSsgPwBQfrZ1KZYpzDspWLZ6/yLMMZrtq4pVqNR7C7N96L3SuLpXv1nhQ==
   dependencies:
     fast-base64-decode "^1.0.0"
 
 react-nl2br@^1.0.2:
   version "1.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-nl2br/-/react-nl2br-1.0.2.tgz#ebe2431245caa631242cb10a739ac9bb5b2b6da3"
+  resolved "https://registry.yarnpkg.com/react-nl2br/-/react-nl2br-1.0.2.tgz#ebe2431245caa631242cb10a739ac9bb5b2b6da3"
   integrity sha512-gjuv4thrXRYvDhd82ceW1fr6sBkF9ngESIuwSevznK9hBEh1KXV0SPeZKScVbHWkaKUq1aMTFeIt04JdIz4p7g==
 
 react-qr-code@^2.0.11:
   version "2.0.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-qr-code/-/react-qr-code-2.0.11.tgz#444c759a2100424972e17135fbe0e32eaffa19e8"
+  resolved "https://registry.yarnpkg.com/react-qr-code/-/react-qr-code-2.0.11.tgz#444c759a2100424972e17135fbe0e32eaffa19e8"
   integrity sha512-P7mvVM5vk9NjGdHMt4Z0KWeeJYwRAtonHTghZT2r+AASinLUUKQ9wfsGH2lPKsT++gps7hXmaiMGRvwTDEL9OA==
   dependencies:
     prop-types "^15.8.1"
@@ -9545,7 +9545,7 @@ react-qr-code@^2.0.11:
 
 react-refresh@^0.9.0:
   version "0.9.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
 react-router-dom@^5.2.0:
@@ -9579,7 +9579,7 @@ react-router@5.2.0, react-router@^5.2.0:
 
 react-select@^4.3.0:
   version "4.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/react-select/-/react-select-4.3.0.tgz#6bde634ae7a378b49f3833c85c126f533483fa2e"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.3.0.tgz#6bde634ae7a378b49f3833c85c126f533483fa2e"
   integrity sha512-SBPD1a3TJqE9zoI/jfOLCAoLr/neluaeokjOixr3zZ1vHezkom8K0A9J4QG9IWDqIDE9K/Mv+0y1GjidC2PDtQ==
   dependencies:
     "@babel/runtime" "^7.12.0"
@@ -9707,7 +9707,7 @@ read-pkg@^5.2.0:
 
 read@1.0.5:
   version "1.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/read/-/read-1.0.5.tgz#007a3d169478aa710a491727e453effb92e76203"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.5.tgz#007a3d169478aa710a491727e453effb92e76203"
   integrity sha1-AHo9FpR4qnEKSRcn5FPv+5LnYgM=
   dependencies:
     mute-stream "~0.0.4"
@@ -9770,7 +9770,7 @@ redent@^3.0.0:
 
 redux@^4.0.5:
   version "4.0.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
   dependencies:
     loose-envify "^1.4.0"
@@ -9778,7 +9778,7 @@ redux@^4.0.5:
 
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz#7f442732aa7934a3740c779bb9b3340dccc1fb56"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz#7f442732aa7934a3740c779bb9b3340dccc1fb56"
   integrity sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==
   dependencies:
     regenerate "^1.4.2"
@@ -9797,7 +9797,7 @@ regenerate@^1.4.0, regenerate@^1.4.2:
 
 regenerator-runtime@^0.13.11:
   version "0.13.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 regenerator-runtime@^0.13.4:
@@ -9807,7 +9807,7 @@ regenerator-runtime@^0.13.4:
 
 regenerator-runtime@^0.13.7:
   version "0.13.9"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.14.2:
@@ -9852,7 +9852,7 @@ regexpu-core@^4.7.1:
 
 regexpu-core@^5.0.1:
   version "5.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regexpu-core/-/regexpu-core-5.0.1.tgz#c531122a7840de743dcf9c83e923b5560323ced3"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.0.1.tgz#c531122a7840de743dcf9c83e923b5560323ced3"
   integrity sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==
   dependencies:
     regenerate "^1.4.2"
@@ -9869,7 +9869,7 @@ regjsgen@^0.5.1:
 
 regjsgen@^0.6.0:
   version "0.6.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.6.0.tgz#83414c5354afd7d6627b16af5f10f41c4e71808d"
   integrity sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==
 
 regjsparser@^0.6.4:
@@ -9881,7 +9881,7 @@ regjsparser@^0.6.4:
 
 regjsparser@^0.8.2:
   version "0.8.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/regjsparser/-/regjsparser-0.8.4.tgz#8a14285ffcc5de78c5b95d62bbf413b6bc132d5f"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.8.4.tgz#8a14285ffcc5de78c5b95d62bbf413b6bc132d5f"
   integrity sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==
   dependencies:
     jsesc "~0.5.0"
@@ -9970,14 +9970,14 @@ replace-homedir@^1.0.0:
 
 request-progress@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
+  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
   integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
   dependencies:
     throttleit "^1.0.0"
 
 request@^2.88.0:
   version "2.88.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
   dependencies:
     aws-sign2 "~0.7.0"
@@ -10066,7 +10066,7 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.17.
 
 resolve@^1.14.2:
   version "1.22.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
     is-core-module "^2.8.1"
@@ -10083,7 +10083,7 @@ resolve@^2.0.0-next.3:
 
 restore-cursor@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
   integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   dependencies:
     onetime "^2.0.0"
@@ -10091,7 +10091,7 @@ restore-cursor@^2.0.0:
 
 restore-cursor@^3.1.0:
   version "3.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
   integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
   dependencies:
     onetime "^5.1.0"
@@ -10109,7 +10109,7 @@ reusify@^1.0.4:
 
 rfdc@^1.3.0:
   version "1.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
 rimraf@2:
@@ -10128,7 +10128,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
+  resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
   dependencies:
     hash-base "^3.0.0"
@@ -10143,7 +10143,7 @@ rtl-css-js@^1.14.0:
 
 run-async@^2.2.0:
   version "2.4.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 run-parallel@^1.1.9:
@@ -10155,14 +10155,14 @@ run-parallel@^1.1.9:
 
 rxjs@^6.4.0:
   version "6.6.7"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
 rxjs@^7.5.1:
   version "7.5.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
   integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
   dependencies:
     tslib "^2.1.0"
@@ -10223,7 +10223,7 @@ semver-greatest-satisfied-range@^1.1.0:
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@7.0.0:
@@ -10233,7 +10233,7 @@ semver@7.0.0:
 
 semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.2.1, semver@^7.3.2:
@@ -10265,7 +10265,7 @@ set-value@^2.0.0, set-value@^2.0.1:
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
   dependencies:
     inherits "^2.0.1"
@@ -10304,7 +10304,7 @@ signal-exit@^3.0.2:
 
 sinon@^7.5.0:
   version "7.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
   integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
   dependencies:
     "@sinonjs/commons" "^1.4.0"
@@ -10361,7 +10361,7 @@ slate@^0.59.0:
 
 slice-ansi@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-3.0.0.tgz#31ddc10930a1b7e0b67b08c96c2f49b77a789787"
   integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
   dependencies:
     ansi-styles "^4.0.0"
@@ -10425,7 +10425,7 @@ source-map-resolve@^0.5.0:
 
 source-map-support@~0.5.20:
   version "0.5.21"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
   dependencies:
     buffer-from "^1.0.0"
@@ -10453,7 +10453,7 @@ source-map@^0.6.0, source-map@^0.6.1:
 
 source-map@~0.7.2:
   version "0.7.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-codec@^1.4.8:
@@ -10506,7 +10506,7 @@ split-string@^3.0.1, split-string@^3.0.2:
 
 split@0.3.1:
   version "0.3.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/split/-/split-0.3.1.tgz#cebcf142bf61bbb64b141628e6db482a2914654c"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.1.tgz#cebcf142bf61bbb64b141628e6db482a2914654c"
   integrity sha1-zrzxQr9hu7ZLFBYo5ttIKikUZUw=
   dependencies:
     through "2"
@@ -10518,7 +10518,7 @@ sprintf-js@~1.0.2:
 
 sshpk@^1.14.1:
   version "1.17.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
   integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
   dependencies:
     asn1 "~0.2.3"
@@ -10533,7 +10533,7 @@ sshpk@^1.14.1:
 
 sshpk@^1.7.0:
   version "1.16.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
   integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   dependencies:
     asn1 "~0.2.3"
@@ -10595,7 +10595,7 @@ static-extend@^0.1.1:
 
 stream-browserify@^3.0.0:
   version "3.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
   integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
   dependencies:
     inherits "~2.0.4"
@@ -10622,7 +10622,7 @@ string-width@^1.0.1, string-width@^1.0.2:
 
 string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
     is-fullwidth-code-point "^2.0.0"
@@ -10630,7 +10630,7 @@ string-width@^2.1.0, string-width@^2.1.1:
 
 string-width@^4.1.0:
   version "4.2.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
   dependencies:
     emoji-regex "^8.0.0"
@@ -10716,14 +10716,14 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
 
 strip-ansi@^4.0.0:
   version "4.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
 
 strip-ansi@^5.1.0:
   version "5.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
@@ -10737,7 +10737,7 @@ strip-ansi@^6.0.0:
 
 strip-ansi@^6.0.1:
   version "6.0.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
@@ -10756,7 +10756,7 @@ strip-bom@^2.0.0:
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-indent@^3.0.0:
@@ -10853,7 +10853,7 @@ stylelint@^13.10.0:
 
 stylis@^4.0.3:
   version "4.0.10"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
   integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 stylis@^4.0.6:
@@ -10896,19 +10896,19 @@ supports-color@^7.1.0:
 
 supports-color@^8.1.1:
   version "8.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 surge-fstream-ignore@^1.0.6:
   version "1.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/surge-fstream-ignore/-/surge-fstream-ignore-1.0.6.tgz#e30efce95574b91fd571b5b02f32a611ea829731"
+  resolved "https://registry.yarnpkg.com/surge-fstream-ignore/-/surge-fstream-ignore-1.0.6.tgz#e30efce95574b91fd571b5b02f32a611ea829731"
   integrity sha512-hNN52cz2fYCAzhlHmWPn4aE3bFbpBt01AkWFLljrtSzFvxlipLAeLuLtQ3t4f0RKoUkjzXWCAFK13WoET2iM1A==
   dependencies:
     fstream ">=1.0.12"
@@ -10917,12 +10917,12 @@ surge-fstream-ignore@^1.0.6:
 
 surge-ignore@0.2.0:
   version "0.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/surge-ignore/-/surge-ignore-0.2.0.tgz#5a7f8a20a71188cf9e75a2cfe8eb182de90daf3b"
+  resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.2.0.tgz#5a7f8a20a71188cf9e75a2cfe8eb182de90daf3b"
   integrity sha1-Wn+KIKcRiM+edaLP6OsYLekNrzs=
 
 surge@^0.23.0:
   version "0.23.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/surge/-/surge-0.23.0.tgz#aefb30620221a198c228ed3b9f45a2c4e8b23e74"
+  resolved "https://registry.yarnpkg.com/surge/-/surge-0.23.0.tgz#aefb30620221a198c228ed3b9f45a2c4e8b23e74"
   integrity sha512-9SJEREttCb/aMpp7hcNHh33hniv1Lh3hI22TqHKGHU6YEYU4Iovs11K4vtgWhODAyCY1md2/vHj1M35MI6WnBg==
   dependencies:
     cli-table3 "^0.5.1"
@@ -10956,7 +10956,7 @@ svg-tags@^1.0.0:
 
 svgo@^2.4.0:
   version "2.8.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
   integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
   dependencies:
     "@trysound/sax" "0.2.0"
@@ -10974,7 +10974,7 @@ symbol-observable@^1.2.0:
 
 sync-fetch@^0.2.0:
   version "0.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/sync-fetch/-/sync-fetch-0.2.1.tgz#55cc01d7485bd92cb1fc22fd6270cdf811e787ee"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.2.1.tgz#55cc01d7485bd92cb1fc22fd6270cdf811e787ee"
   integrity sha512-GxcJRiIgg32kjEe90/BTtLeCBOdSR5ShfxbQNrB3duVKbuf7lnjmC4aT3y/Bu1t84j5Uio80IoDQZ4uOHrtTHQ==
   dependencies:
     buffer "^5.7.0"
@@ -10992,7 +10992,7 @@ table@^6.0.4, table@^6.0.7:
 
 tarr@1.1.0:
   version "1.1.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tarr/-/tarr-1.1.0.tgz#d7a9532ce97f08f5200b78ae0a82a6883173c8c8"
+  resolved "https://registry.yarnpkg.com/tarr/-/tarr-1.1.0.tgz#d7a9532ce97f08f5200b78ae0a82a6883173c8c8"
   integrity sha512-tENbQ43IQckay71stp1p1lljRhoEZpZk10FzEZKW2tJcMcnLwV3CfZdxBAERlH6nwnFvnHMS9eJOJl6IzSsG0g==
   dependencies:
     block-stream "*"
@@ -11001,12 +11001,12 @@ tarr@1.1.0:
 
 term-size@^2.2.1:
   version "2.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
   integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
 terser@^5.2.0:
   version "5.12.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.12.1.tgz#4cf2ebed1f5bceef5c83b9f60104ac4a78b49e9c"
   integrity sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==
   dependencies:
     acorn "^8.5.0"
@@ -11031,7 +11031,7 @@ throttle-debounce@^2.1.0:
 
 throttleit@^1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
   integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
 
 through2-filter@^3.0.0:
@@ -11077,7 +11077,7 @@ time-stamp@^1.0.0:
 
 timsort@^0.3.0:
   version "0.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
+  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
 tiny-emitter@^2.0.0:
@@ -11104,14 +11104,14 @@ tippy.js@^6.2.0:
 
 tmp@^0.0.33:
   version "0.0.33"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
 
 tmp@~0.2.1:
   version "0.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
     rimraf "^3.0.0"
@@ -11194,7 +11194,7 @@ toggle-selection@^1.0.6:
 
 tough-cookie@~2.5.0:
   version "2.5.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
     psl "^1.1.28"
@@ -11227,7 +11227,7 @@ tslib@^2.0.0:
 
 tslib@^2.1.0:
   version "2.4.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tunnel-agent@^0.6.0:
@@ -11239,7 +11239,7 @@ tunnel-agent@^0.6.0:
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
 type-check@^0.4.0, type-check@~0.4.0:
@@ -11251,7 +11251,7 @@ type-check@^0.4.0, type-check@~0.4.0:
 
 type-detect@4.0.8:
   version "4.0.8"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.18.0:
@@ -11261,12 +11261,12 @@ type-fest@^0.18.0:
 
 type-fest@^0.20.2:
   version "0.20.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.21.3:
   version "0.21.3"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.6.0:
@@ -11303,12 +11303,12 @@ typedarray@^0.0.6:
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 ulid@2.3.0:
   version "2.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/ulid/-/ulid-2.3.0.tgz#93063522771a9774121a84d126ecd3eb9804071f"
+  resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.3.0.tgz#93063522771a9774121a84d126ecd3eb9804071f"
   integrity sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==
 
 unc-path-regex@^0.1.2:
@@ -11344,7 +11344,7 @@ undertaker@^1.2.1:
 
 unfetch@^4.2.0:
   version "4.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
   integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
@@ -11354,7 +11354,7 @@ unicode-canonical-property-names-ecmascript@^1.0.4:
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz#301acdc525631670d39f6146e0e77ff6bbdebddc"
   integrity sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==
 
 unicode-match-property-ecmascript@^1.0.4:
@@ -11367,7 +11367,7 @@ unicode-match-property-ecmascript@^1.0.4:
 
 unicode-match-property-ecmascript@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
   integrity sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==
   dependencies:
     unicode-canonical-property-names-ecmascript "^2.0.0"
@@ -11380,7 +11380,7 @@ unicode-match-property-value-ecmascript@^1.2.0:
 
 unicode-match-property-value-ecmascript@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz#1a01aa57247c14c568b89775a54938788189a714"
   integrity sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==
 
 unicode-property-aliases-ecmascript@^1.0.4:
@@ -11390,7 +11390,7 @@ unicode-property-aliases-ecmascript@^1.0.4:
 
 unicode-property-aliases-ecmascript@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz#0a36cb9a585c4f6abd51ad1deddb285c165297c8"
   integrity sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==
 
 unified@^9.1.0:
@@ -11449,7 +11449,7 @@ unist-util-stringify-position@^2.0.0:
 
 universal-cookie@^4.0.4:
   version "4.0.4"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
   integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
   dependencies:
     "@types/cookie" "^0.3.3"
@@ -11457,7 +11457,7 @@ universal-cookie@^4.0.4:
 
 universalify@^2.0.0:
   version "2.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
@@ -11470,7 +11470,7 @@ unset-value@^1.0.0:
 
 untildify@^4.0.0:
   version "4.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.1.1:
@@ -11492,7 +11492,7 @@ urix@^0.1.0:
 
 url-parse-as-address@1.0.0:
   version "1.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz#fb80901883f338b3cbed3538f5faa26adaf7f2e7"
+  resolved "https://registry.yarnpkg.com/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz#fb80901883f338b3cbed3538f5faa26adaf7f2e7"
   integrity sha1-+4CQGIPzOLPL7TU49fqiatr38uc=
 
 url@^0.11.0:
@@ -11520,7 +11520,7 @@ utility-types@^3.10.0:
 
 uuid@3.3.2:
   version "3.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2:
@@ -11530,12 +11530,12 @@ uuid@^3.0.0, uuid@^3.2.1, uuid@^3.3.2:
 
 uuid@^8.3.2:
   version "8.3.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.0:
   version "2.3.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
@@ -11570,7 +11570,7 @@ value-or-function@^3.0.0:
 
 verror@1.10.0:
   version "1.10.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
   dependencies:
     assert-plus "^1.0.0"
@@ -11670,12 +11670,12 @@ vinyl@^2.0.0, vinyl@^2.1.0, vinyl@^2.2.1:
 
 weak-lru-cache@^1.2.2:
   version "1.2.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
   integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
 
 whatwg-fetch@^3.4.1:
   version "3.6.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
   integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 which-module@^1.0.0:
@@ -11699,12 +11699,12 @@ which@^2.0.1:
 
 wikibase-sdk@^7.11.1:
   version "7.11.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/wikibase-sdk/-/wikibase-sdk-7.11.1.tgz#4384b3c89485e3038df459d4d0beff4524ea13c5"
+  resolved "https://registry.yarnpkg.com/wikibase-sdk/-/wikibase-sdk-7.11.1.tgz#4384b3c89485e3038df459d4d0beff4524ea13c5"
   integrity sha512-affAamti2V69czAQoxHk0X4MuQaFU04jGCjXhvvsMeMnC2mhUmzSBibkCRPthB6vlS5dY6B8KDCWwygmVoiTHg==
 
 wikidata-sdk@7:
   version "7.11.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/wikidata-sdk/-/wikidata-sdk-7.11.1.tgz#400e2ef9d3bfd79377093a841f4db6cd3593e001"
+  resolved "https://registry.yarnpkg.com/wikidata-sdk/-/wikidata-sdk-7.11.1.tgz#400e2ef9d3bfd79377093a841f4db6cd3593e001"
   integrity sha512-oXmLcCo0Qd3xY4G5ZY4YFS34WUJBBWjKdYK/Sg8ns6PXmgp2fl7E9rYyxWFXxPsmyxbi9zTyXXipN/fTuHpGxQ==
   dependencies:
     wikibase-sdk "^7.11.1"
@@ -11724,7 +11724,7 @@ wrap-ansi@^2.0.0:
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
     ansi-styles "^4.0.0"
@@ -11733,7 +11733,7 @@ wrap-ansi@^6.2.0:
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
@@ -11762,7 +11762,7 @@ xtend@~4.0.0, xtend@~4.0.1:
 
 xxhash-wasm@^0.4.2:
   version "0.4.2"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz#752398c131a4dd407b5132ba62ad372029be6f79"
+  resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz#752398c131a4dd407b5132ba62ad372029be6f79"
   integrity sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==
 
 y18n@^3.2.1:
@@ -11777,7 +11777,7 @@ yallist@^4.0.0:
 
 yaml-front-matter@^4.1.1:
   version "4.1.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/yaml-front-matter/-/yaml-front-matter-4.1.1.tgz#66eaa9a998fc3dd723708c73aa8e06e79cac91c9"
+  resolved "https://registry.yarnpkg.com/yaml-front-matter/-/yaml-front-matter-4.1.1.tgz#66eaa9a998fc3dd723708c73aa8e06e79cac91c9"
   integrity sha512-ULGbghCLsN8Hs8vfExlqrJIe8Hl2TUjD7/zsIGMP8U+dgRXEsDXk4yydxeZJgdGiimP1XB7zhmhOB4/HyfqOyQ==
   dependencies:
     commander "^6.2.0"
@@ -11822,7 +11822,7 @@ yargs@^7.1.0:
 
 yauzl@^2.10.0:
   version "2.10.0"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
   dependencies:
     buffer-crc32 "~0.2.3"
@@ -11830,7 +11830,7 @@ yauzl@^2.10.0:
 
 zen-observable-ts@0.8.19:
   version "0.8.19"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
   integrity sha512-u1a2rpE13G+jSzrg3aiCqXU5tN2kw41b+cBZGmnc+30YimdkKiDj9bTowcB41eL77/17RF/h+393AuVgShyheQ==
   dependencies:
     tslib "^1.9.3"
@@ -11838,17 +11838,17 @@ zen-observable-ts@0.8.19:
 
 zen-observable@^0.7.0:
   version "0.7.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"
   integrity sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg==
 
 zen-observable@^0.8.0:
   version "0.8.15"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zen-push@0.2.1:
   version "0.2.1"
-  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/zen-push/-/zen-push-0.2.1.tgz#ddc33b90f66f9a84237d5f1893970f6be60c3c28"
+  resolved "https://registry.yarnpkg.com/zen-push/-/zen-push-0.2.1.tgz#ddc33b90f66f9a84237d5f1893970f6be60c3c28"
   integrity sha512-Qv4qvc8ZIue51B/0zmeIMxpIGDVhz4GhJALBvnKs/FRa2T7jy4Ori9wFwaHVt0zWV7MIFglKAHbgnVxVTw7U1w==
   dependencies:
     zen-observable "^0.7.0"


### PR DESCRIPTION
Apt used a private DS registry for npm packages which was causing the build to break and is no longer needed.
