### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN mkdir /apt-frontend
 WORKDIR /apt-frontend
 
 COPY .prettierrc /apt-frontend/.prettierrc
-COPY .npmrc /apt-frontend/.npmrc
 COPY package.json /apt-frontend
 COPY yarn.lock /apt-frontend
 COPY gulpfile.js /apt-frontend


### PR DESCRIPTION
We removed the `.npmrc` file in https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/449. This PR removes the step from the docker build process that tries to copy the `.npmrc` file.
