### PR TITLE
Increase PDF retry amount and 201 timeout

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -44,7 +44,9 @@ export default function DocumentDownloadMenu(props) {
     const { id, version, alias } = atbd;
     const pdfUrl = `${apiUrl}/atbds/${id}/versions/${version}/pdf`;
     const pdfFileName = `${alias}-v${version}.pdf`;
-    const maxRetries = 50;
+    // maxRetries * waitBetweenTries = time before user is given an error toast
+    // 30 * 5000 = 150s
+    const maxRetries = 30;
     const waitBetweenTries = 5000;
     const toast = createProcessToast('Downloading PDF, please wait...');
     const initialWait = 10000;
@@ -88,7 +90,9 @@ export default function DocumentDownloadMenu(props) {
             }, waitBetweenTries);
             ++retryCount;
           } else {
-            toast.error('Failed to download PDF!');
+            toast.error(
+              'Failed to download PDF. Please retry after several minutes. If this error persists, please contact the APT team.'
+            );
           }
           return;
         }

--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -106,7 +106,7 @@ export default function DocumentDownloadMenu(props) {
 
           setTimeout(() => {
             fetchPdf(`${pdfUrl}?retry=true`);
-          }, 30000);
+          }, 10000);
           ++retryCount;
 
           return;

--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -47,6 +47,7 @@ export default function DocumentDownloadMenu(props) {
     const maxRetries = 50;
     const waitBetweenTries = 5000;
     const toast = createProcessToast('Downloading PDF, please wait...');
+    const initialWait = 10000;
     let retryCount = 0;
 
     async function fetchPdf(url) {
@@ -106,7 +107,7 @@ export default function DocumentDownloadMenu(props) {
 
           setTimeout(() => {
             fetchPdf(`${pdfUrl}?retry=true`);
-          }, 10000);
+          }, initialWait);
           ++retryCount;
 
           return;

--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -44,7 +44,7 @@ export default function DocumentDownloadMenu(props) {
     const { id, version, alias } = atbd;
     const pdfUrl = `${apiUrl}/atbds/${id}/versions/${version}/pdf`;
     const pdfFileName = `${alias}-v${version}.pdf`;
-    const maxRetries = 10;
+    const maxRetries = 50;
     const waitBetweenTries = 5000;
     const toast = createProcessToast('Downloading PDF, please wait...');
     let retryCount = 0;
@@ -106,7 +106,7 @@ export default function DocumentDownloadMenu(props) {
 
           setTimeout(() => {
             fetchPdf(`${pdfUrl}?retry=true`);
-          }, 3000);
+          }, 30000);
           ++retryCount;
 
           return;


### PR DESCRIPTION
Upstream: https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/451

Increases the time that PDFs can try to generate before succeeding/failing. We can reduce the increased numbers if they're too extreme or cause issues elsewhere