### PR TITLE
Add spaces between authors in reference section

### DIFF
--- a/app/assets/scripts/utils/references.js
+++ b/app/assets/scripts/utils/references.js
@@ -116,10 +116,10 @@ function formatAuthors(authors, type = 'reference') {
       const lastAuthor = authorNames[authorNames.length - 1];
       return `${authorNames
         .slice(0, authorNames.length - 1)
-        .join(',')} & ${lastAuthor}`;
+        .join(', ')} & ${lastAuthor}`;
     }
     if (authorNames.length >= 8) {
-      return `${authorNames.slice(0, 7).join(',')} et al.`;
+      return `${authorNames.slice(0, 7).join(', ')} et al.`;
     }
   }
   return authorStr;


### PR DESCRIPTION
Upstream: https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/446#issuecomment-1496418743

Removes spaces between authors in the reference section when two or more authors are present.