### PR TITLE
Increase retry count for PDF generation delivery

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -52,7 +52,7 @@ export default function DocumentDownloadMenu(props) {
 
     async function fetchPdf(url) {
       if (retryCount > 0) {
-        toast.update('Generating the PDF. This may take a minute...');
+        toast.update('Generating the PDF. This may take up to 5 minutes.');
       }
       const user = await Auth.currentAuthenticatedUser();
       if (!user) {

--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -44,9 +44,7 @@ export default function DocumentDownloadMenu(props) {
     const { id, version, alias } = atbd;
     const pdfUrl = `${apiUrl}/atbds/${id}/versions/${version}/pdf`;
     const pdfFileName = `${alias}-v${version}.pdf`;
-    // maxRetries * waitBetweenTries = time before user is given an error toast
-    // 30 * 5000 = 150s
-    const maxRetries = 30;
+    const maxRetries = 50;
     const waitBetweenTries = 5000;
     const toast = createProcessToast('Downloading PDF, please wait...');
     const initialWait = 10000;


### PR DESCRIPTION
Upstream: https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/451#issuecomment-1498709846, https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/452

Further increases time that the Document PDF can generate before a user is given an error message (250s).
