### PR TITLE
Update pdf download mechanism

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -115,14 +115,15 @@ export default function DocumentDownloadMenu(props) {
           return;
         }
 
-        // If we get a 200 and content-type is application/pdf, it means the
-        // PDF is ready for download. Download the PDF blob and save it.
+        // If we get a 200, it means the PDF is ready for download.
+        // We get the s3 url and use file saver to download and save the pdf.
         if (
           response.status === 200 &&
-          response.headers.get('content-type') === 'application/pdf'
+          response.headers.get('content-type') === 'application/json'
         ) {
-          const pdfBlob = await response.blob();
-          saveAs(pdfBlob, pdfFileName);
+          const result = await response.json();
+
+          await saveAs(result.pdf_url, pdfFileName);
           toast.success('PDF downloaded successfully!');
           return;
         }


### PR DESCRIPTION
Note:  We're using [`file-saver`](https://www.npmjs.com/package/file-saver) to download the pdf. And from the documentation
![2023-04-27-182318](https://user-images.githubusercontent.com/4931541/234864879-134b2394-e93a-4890-b89f-82dc5086477c.png)

Which means we'll still get and CORS error (at least in the development mode) but it'll download afterwards using the anchor element.

We can solve this issue by updating the CORS policy in the s3
