### PR TITLE
Adds separate Edit Button 

### DIFF
--- a/app/assets/scripts/components/documents/document-governance-action.js
+++ b/app/assets/scripts/components/documents/document-governance-action.js
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import T from 'prop-types';
 import { Button } from '@devseed-ui/button';
+import { documentEdit } from '../../utils/url-creator';
+import { Link } from '../../styles/clean/link';
 
 import DropdownMenu from '../common/dropdown-menu';
 import ButtonSecondary from '../../styles/button-secondary';
@@ -45,6 +47,18 @@ export default function DocumentGovernanceAction(props) {
 
   return (
     <React.Fragment>
+      <Can do='edit' on={atbd}>
+        <control.El
+          {...control.props}
+          title='Edit report'
+          disabled={isMutating}
+          useIcon='pencil'
+          to={documentEdit(atbd, version)}
+          forwardedAs={Link}
+        >
+          Edit
+        </control.El>
+      </Can>
       <Can do='req-review' on={atbd}>
         <control.El
           {...control.props}


### PR DESCRIPTION
Contributes to [#632](https://github.com/NASA-IMPACT/nasa-apt/issues/632)

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/719357/235994300-0979c866-9aa2-43c2-b94b-c51c540bb0cf.png">


@wrynearson I tried adding an Exit Editing button but because of the Step Counter it didn't fit well in the header.