### PR TITLE
Add video to create ATBD page

### DIFF
--- a/app/assets/scripts/components/new-atbd/index.js
+++ b/app/assets/scripts/components/new-atbd/index.js
@@ -106,12 +106,10 @@ const Section = styled.section`
   gap: ${glsp(1.5)};
 `;
 
-/*
 const Video = styled.iframe`
   width: 100%;
   height: 20rem;
 `;
-*/
 
 const TemplateContainer = styled.div`
   display: flex;
@@ -203,6 +201,12 @@ function NewAtbd() {
             <div>
               See <Link to='/user-guide'>APT user guide</Link>
             </div>
+            <Video
+              src='https://drive.google.com/file/d/1D9WpNJh3teOCLMbb_gDeJyIWjqarySyk/view'
+              title='APT - creating a document'
+              frameborder='0'
+              allowfullscreen
+            />
           </Section>
           <Section>
             <h2>ATBD Templates</h2>


### PR DESCRIPTION
From https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/474

@frozenhelium – could help display this [Google Drive video](https://drive.google.com/file/d/1D9WpNJh3teOCLMbb_gDeJyIWjqarySyk/view?usp=share_link) in the video frame on the new 
