### PR TITLE
Temporarily disable Journal PDF download

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -9,7 +9,6 @@ import { createProcessToast } from '../common/toasts';
 
 import { apiUrl } from '../../config';
 import { useAuthToken } from '../../context/user';
-import { useContextualAbility } from '../../a11n';
 
 function DropMenuItemOutboundLink(props) {
   const { eventLabel, menuItem, active, ...rest } = props;

--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -37,8 +37,11 @@ export default function DocumentDownloadMenu(props) {
   const { atbd, hideText, variation, alignment, direction, onChange } = props;
   const { token } = useAuthToken();
 
-  const ability = useContextualAbility();
-  const canDownloadJournalPdf = ability.can('download-journal-pdf', atbd);
+  // TODO: Fix Journal PDF downloading
+  // Temporarily disable journal PDF downloading https://github.com/nasa-impact/nasa-apt/issues/744
+  // const ability = useContextualAbility();
+  //const canDownloadJournalPdf = ability.can('download-journal-pdf', atbd);
+  const canDownloadJournalPdf = false;
 
   const handlePdfDownloadClick = React.useCallback(() => {
     const { id, version, alias } = atbd;


### PR DESCRIPTION
* Fix for https://github.com/nasa-impact/nasa-apt/issues/744
* Temporarily set `canDownloadJournalPDF` to false until Journal PDF functionality is fixed
