### PR TITLE
Add blocked popup text to PDF download success toast

### DIFF
--- a/app/assets/scripts/components/documents/document-download-menu.js
+++ b/app/assets/scripts/components/documents/document-download-menu.js
@@ -153,7 +153,9 @@ export default function DocumentDownloadMenu(props) {
           const result = await response.json();
 
           saveAs(result.pdf_url, pdfFileName);
-          processToast.success('PDF downloaded successfully!');
+          processToast.success(
+            'PDF downloaded successfully! If the PDF did not open automatically, your browser may have blocked the download. Please make sure that popups are allowed on this site.'
+          );
           return;
         }
 


### PR DESCRIPTION
Upstream: https://github.com/NASA-IMPACT/nasa-apt/issues/770

Reviewer should:

- [ ] Shorten the text, or link to the [Chrome help docs](https://support.google.com/chrome/answer/95472?hl=en&co=GENIE.Platform=Desktop#zippy=%2Callow-pop-ups-and-redirects-from-a-site:~:text=from%20a%20site-,On%20your%20computer%2C%20open%20Chrome.,-Go%20to%20a), if they think it would be more user friendly