### PR TITLE
Fix Reference Edit and Select buttons

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/step-references/references-manager.js
+++ b/app/assets/scripts/components/documents/single-edit/step-references/references-manager.js
@@ -101,7 +101,7 @@ export default function ReferencesManager(props) {
     <FieldArray
       name='document.publication_references'
       render={(arrayHelpers) => {
-        const { remove, push, form, name } = arrayHelpers;
+        const { remove, push, form, name, move } = arrayHelpers;
         const values = get(form.values, name);
 
         // Update the refs list. See note above
@@ -172,6 +172,9 @@ export default function ReferencesManager(props) {
                           { meta: e.metaKey || e.ctrlKey, shift: e.shiftKey }
                         );
                         setRefsEditing(newSelection);
+
+                        // This is a hack to force the field to re-render
+                        move(index, index);
                       }}
                       onDeleteClick={async () => {
                         // If the reference is in use prompt the user for
@@ -205,6 +208,9 @@ export default function ReferencesManager(props) {
                           { meta: true, shift: e.shiftKey }
                         );
                         setRefsSelected(newSelection);
+
+                        // This is a hack to force the field to re-render
+                        move(index, index);
                       }}
                     />
                   ))}


### PR DESCRIPTION
The state of the modal depends on the variables `selectedReferencesList` and `editingReferencesList`, selection lists that depend on the state variables `refsSelected` and `refsEditing` respectively. However, when toggling the edit button or selection checkboxes, the state variables are edited but the dependent variables are not changed. This is because the field itself never re-renders.

I wrote a hack (should not impact performance) that touches the internal array of the form but does not modify it using `move(index, index)`. This forces the field to re-render. I'm sure there are better ways of doing this, but it might require a re-architecting of the state variables in this module.