### PR TITLE
Parse latex equation int the format {{~equation~}}

### DIFF
--- a/app/assets/scripts/components/dashboard/document-dashboard-entry.js
+++ b/app/assets/scripts/components/dashboard/document-dashboard-entry.js
@@ -27,6 +27,7 @@ import DocumentCommentsButton from '../documents/document-comment-button';
 import { documentView } from '../../utils/url-creator';
 import { computeAtbdVersion } from '../../context/atbds-list';
 import getDocumentIdKey from '../documents/get-document-id-key';
+import { resolveTitle } from '../../utils/common';
 
 function DocumentDashboardEntry(props) {
   const { atbd, onDocumentAction } = props;
@@ -77,7 +78,7 @@ function DocumentDashboardEntry(props) {
                 to={documentView(atbd, lastVersion.version)}
                 title={`View ${atbd.title}`}
               >
-                {atbd.title}
+                {resolveTitle(atbd.title)}
               </Link>
             </DocumentEntryTitle>
             <DocumentEntryNav role='navigation'>

--- a/app/assets/scripts/components/documents/document-headline.js
+++ b/app/assets/scripts/components/documents/document-headline.js
@@ -18,6 +18,7 @@ import { DateButton } from '../common/date';
 import { CollaboratorsMenu } from './collaborators-menu';
 import DocumentCommentsButton from './document-comment-button';
 
+import { resolveTitle } from '../../utils/common';
 import { Can, useContextualAbility } from '../../a11n';
 import { useUser } from '../../context/user';
 import { documentEdit, documentView } from '../../utils/url-creator';
@@ -105,7 +106,7 @@ export default function DocumentHeadline(props) {
         <InpageHeadHgroup>
           <TruncatedInpageTitle>
             <Link to={documentView(atbd, version)} title={`View ${title}`}>
-              {title}
+              {resolveTitle(title)}
             </Link>
           </TruncatedInpageTitle>
           <InpageHeadNav role='navigation'>

--- a/app/assets/scripts/components/documents/hub/document-hub-entry.js
+++ b/app/assets/scripts/components/documents/hub/document-hub-entry.js
@@ -26,6 +26,7 @@ import getDocumentIdKey from '../get-document-id-key';
 import { computeAtbdVersion } from '../../../context/atbds-list';
 import { SafeReadEditor } from '../../slate';
 import { truncateSlateObject } from '../../slate/plugins/common/text-utils';
+import { resolveTitle } from '../../../utils/common';
 
 const getDropChange = (label) => (isOpen) =>
   isOpen &&
@@ -63,7 +64,7 @@ function DocumentHubEntry(props) {
       <CardHeader>
         <CardHeadline>
           <CardHgroup>
-            <CardTitle>{atbd.title}</CardTitle>
+            <CardTitle>{resolveTitle(atbd.title)}</CardTitle>
             <CardToolbar>
               {atbd.document_type === 'PDF' && (
                 <BsFilePdf title='PDF type document' />

--- a/app/assets/scripts/components/documents/new-atbd-modal.js
+++ b/app/assets/scripts/components/documents/new-atbd-modal.js
@@ -9,6 +9,8 @@ import { glsp } from '@devseed-ui/theme-provider';
 
 import FormInfoTip from '../common/forms/form-info-tooltip';
 import { useDocumentCreate } from '../documents/single-edit/use-document-create';
+import { resolveTitle } from '../../utils/common';
+import { formString } from '../../utils/strings';
 
 const StyledFormInput = styled(FormInput)`
   width: 100%;
@@ -65,7 +67,12 @@ function NewATBDModal(props) {
       content={
         <ModalContent>
           <FormGroup>
-            <FormLabel htmlFor='atbd-title'>ATBD Title</FormLabel>
+            <FormLabel htmlFor='atbd-title'>
+              ATBD Title{' '}
+              <FormInfoTip
+                title={formString('identifying_information.title')}
+              />
+            </FormLabel>
             <StyledFormInput
               id='atbd-title'
               type='text'
@@ -74,9 +81,15 @@ function NewATBDModal(props) {
               onChange={handleTitleInputChange}
               autoFocus
             />
+            <h4>Preview: {resolveTitle(title)}</h4>
           </FormGroup>
           <FormGroup>
-            <FormLabel htmlFor='atbd-alias'>Alias</FormLabel>
+            <FormLabel htmlFor='atbd-alias'>
+              Alias{' '}
+              <FormInfoTip
+                title={formString('identifying_information.alias')}
+              />
+            </FormLabel>
             <StyledFormInput
               id='atbd-alias'
               type='text'

--- a/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
+++ b/app/assets/scripts/components/documents/single-edit/step-identifying-information.js
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import T from 'prop-types';
 import set from 'lodash.set';
-import { Formik, Form as FormikForm } from 'formik';
+import { Formik, Form as FormikForm, useField } from 'formik';
 import { Form, FormHelperMessage } from '@devseed-ui/form';
 
 import { Inpage, InpageBody } from '../../../styles/inpage';
@@ -27,6 +27,13 @@ import { isPublished } from '../status';
 import { LocalStore } from './local-store';
 import { FormikUnloadPrompt } from '../../common/unload-prompt';
 import RichTextContex2Formik from './rich-text-ctx-formik';
+import { resolveTitle } from '../../../utils/common';
+
+function TitlePreview() {
+  const [{ value }] = useField('title');
+
+  return <h4>Preview: {resolveTitle(value)}</h4>;
+}
 
 export default function StepIdentifyingInformation(props) {
   const { renderInpageHeader, renderFormFooter, atbd, id, version, step } =
@@ -100,6 +107,7 @@ export default function StepIdentifyingInformation(props) {
                     name='title'
                     label='ATBD Title'
                     description={formString('identifying_information.title')}
+                    helper={<TitlePreview />}
                   />
                   <FieldAtbdAlias disabled={hasAnyVersionPublished} />
                 </SectionFieldset>

--- a/app/assets/scripts/components/documents/single-view/document-title.js
+++ b/app/assets/scripts/components/documents/single-view/document-title.js
@@ -10,6 +10,7 @@ import { CopyField } from '../../common/copy-field';
 import Datetime from '../../common/date';
 import Tip from '../../common/tooltip';
 import DetailsList from '../../../styles/typography/details-list';
+import { resolveTitle } from '../../../utils/common';
 
 const DocumentHeader = styled.header`
   display: grid;
@@ -163,7 +164,7 @@ function DocumentTitle(props) {
   return (
     <DocumentHeader>
       <DocumentHeading id='doc-header' data-scroll='target'>
-        {atbdData.title}
+        {resolveTitle(atbdData.title)}
       </DocumentHeading>
       <DocumentMetaDetails>
         <dt>Version</dt>

--- a/app/assets/scripts/utils/common.js
+++ b/app/assets/scripts/utils/common.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { InlineMath } from 'react-katex';
+
 import config from '../config';
 import { getAppURL } from './history';
 
@@ -24,4 +26,43 @@ export function useBooleanState(initialValue) {
   }, []);
 
   return [value, setValueTrue, setValueFalse, toggleValue];
+}
+
+export function resolveTitle(title) {
+  if (!title || title === '') {
+    return '';
+  }
+
+  const start = '{{';
+  const end = '}}';
+
+  const parts = title.split(start);
+  const resolvedParts = parts.map((part) => {
+    const endIndex = part.indexOf(end);
+
+    if (endIndex === -1) {
+      return part;
+    }
+
+    const key = part.substring(0, endIndex);
+    const value = <InlineMath math={key} />;
+
+    return (
+      <>
+        {/* And, replace with associated component */}
+        {value}
+        {/* Remove the key */}
+        {part.replace(`${key}${end}`, '')}
+      </>
+    );
+  });
+
+  return (
+    <>
+      {resolvedParts.map((d, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <React.Fragment key={i}>{d}</React.Fragment>
+      ))}
+    </>
+  );
 }

--- a/content/strings/identifying_information.yml
+++ b/content/strings/identifying_information.yml
@@ -1,4 +1,4 @@
-title: The descriptive title of your ATBD.
+title: "The descriptive title of your ATBD. You can add latex snippet insde double curly braces. Eg: Example title {{x^2}}"
 alias: A short name for referring to the ATBD (less  than 32 characters).  Once the ATBD is completed, the short name will not be editable.
 doi: The DOI is typically assigned by the curator. Only add a DOI for historical documents that have been published and already have a DOI.
 version_description: Provide a brief and meaningful description of how this APT ATBD version differs from any previous one. Providing a lineage of algorithm versions is equally important.

--- a/content/strings/identifying_information.yml
+++ b/content/strings/identifying_information.yml
@@ -1,4 +1,4 @@
-title: "The descriptive title of your ATBD. You can add latex snippet insde double curly braces. Eg: Example title {{x^2}}"
+title: 'The descriptive title of your ATBD. You can add LaTeX snippets inside double curly braces. E.g., Example title {{x^2}}'
 alias: A short name for referring to the ATBD (less  than 32 characters).  Once the ATBD is completed, the short name will not be editable.
 doi: The DOI is typically assigned by the curator. Only add a DOI for historical documents that have been published and already have a DOI.
 version_description: Provide a brief and meaningful description of how this APT ATBD version differs from any previous one. Providing a lineage of algorithm versions is equally important.


### PR DESCRIPTION
Title parse in:
- [x] Main heading in view mode
- [x] Title in headline
- [x] Title Document hub entry
- [x] Title in Dashboard entry
- [x] Title in pdf export

### Add equation between `{{` and `}}`
![2023-08-02-204310](https://github.com/NASA-IMPACT/nasa-apt-frontend/assets/4931541/b4a674e2-3b30-4640-84d3-c48e6206ee2d)

### Result
![2023-08-02-204254](https://github.com/NASA-IMPACT/nasa-apt-frontend/assets/4931541/b180ab26-8213-4e63-9904-b9eed5846581)

Addresses: https://github.com/NASA-IMPACT/nasa-apt/issues/586


