### PR TITLE
change ref font-size

### DIFF
--- a/app/assets/scripts/components/slate/plugins/reference/reference.js
+++ b/app/assets/scripts/components/slate/plugins/reference/reference.js
@@ -60,7 +60,6 @@ const Ref = styled.span`
 `;
 
 const RefReadOnly = styled.span`
-  padding: ${glsp(0, 0.25)};
   font-size: 1rem;
 `;
 

--- a/app/assets/scripts/components/slate/plugins/reference/reference.js
+++ b/app/assets/scripts/components/slate/plugins/reference/reference.js
@@ -61,7 +61,7 @@ const Ref = styled.span`
 
 const RefReadOnly = styled.span`
   padding: ${glsp(0, 0.25)};
-  font-size: 0.75rem;
+  font-size: 1rem;
 `;
 
 const Spacer = styled.span`


### PR DESCRIPTION
Changes the ref font size to match the rest of the body text:

<img width="743" alt="image" src="https://github.com/NASA-IMPACT/nasa-apt-frontend/assets/719357/e36dbcaa-b40c-44b5-91b8-156c921e500c">
