### PR TITLE
Get create errors from server

### DIFF
--- a/app/assets/scripts/components/documents/single-edit/use-document-create.js
+++ b/app/assets/scripts/components/documents/single-edit/use-document-create.js
@@ -18,7 +18,20 @@ export function useDocumentCreate(title, alias, isPdfType) {
     const result = await createAtbd(title, alias, isPdfType);
 
     if (result.error) {
-      processToast.error(`An error occurred: ${result.error.message}`);
+      if (result.error.response) {
+        const { status } = result.error.response;
+        if (status === 400) {
+          processToast.error(
+            `An error occurred: ${result.error.response.data.detail}`
+          );
+        } else {
+          processToast.error(
+            `An error occurred: ${result.error.response.statusText}`
+          );
+        }
+      } else {
+        processToast.error(`An error occurred: ${result.error.message}`);
+      }
     } else {
       processToast.success('Document successfully created');
       // To trigger the modals to open from other pages, we use the history


### PR DESCRIPTION
More readable messages when getting create errors from the server: the user knows that a document alias is not available when submitting a form with the same title.

![image](https://github.com/NASA-IMPACT/nasa-apt-frontend/assets/719357/3d39fd98-b209-436e-b187-bc5fdd4da255)

Addresses https://github.com/NASA-IMPACT/nasa-apt/issues/779