### PR TITLE
Add table numbers

### DIFF
--- a/app/assets/scripts/components/documents/journal-pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/journal-pdf-preview/index.js
@@ -23,6 +23,7 @@ import {
   formatReference,
   sortReferences
 } from '../../../utils/references';
+import get from 'lodash.get';
 
 const ReferencesList = styled.ol`
   && {
@@ -310,6 +311,99 @@ function JournalPdfPreview() {
 
   const { keywords, document, contacts_link } = atbd;
 
+  // Section id list in the order they should appear in the document
+  const documentSectionIds = [
+    'key_points',
+    'abstract',
+    'plain_summary',
+    'publication_references',
+    'version_description',
+    'introduction',
+    'historical_perspective',
+    'additional_information',
+    'scientific_theory',
+    'scientific_theory_assumptions',
+    'mathematical_theory',
+    'mathematical_theory_assumptions',
+    'algorithm_input_variables',
+    'algorithm_output_variables',
+    'algorithm_usage_constraints',
+    'performance_assessment_validation_errors',
+    'performance_assessment_validation_methods',
+    'performance_assessment_validation_uncertainties',
+    'algorithm_implementations',
+    'data_access_input_data',
+    'data_access_output_data',
+    'data_access_related_urls',
+    'journal_discussion',
+    'data_availability',
+    'journal_acknowledgements'
+  ];
+
+  // Process sections to add table numbers to captions
+  const sections = documentSectionIds.reduce(
+    (doc, sectionId) => {
+      const section = doc[sectionId];
+
+      // Ensure the section exists
+      if (!section) return doc;
+
+      // If the section has no children, return the section as is
+      if (!section.children) {
+        return {
+          ...doc,
+          [sectionId]: section
+        };
+      }
+
+      // Init table count for this section
+      let tableCount = doc.tableCount;
+
+      const nextDoc = {
+        ...doc,
+        [sectionId]: {
+          ...section,
+          children: section.children.map((child) => {
+            // Ignore non-table blocks
+            if (child.type !== TABLE_BLOCK) {
+              return child;
+            }
+
+            // Reverse the table rows to make caption appear first
+            // and add the table number to the caption
+            return {
+              ...child,
+              children: child.children.reverse().map((c) => {
+                if (c.type !== 'caption') {
+                  return c;
+                }
+
+                const currentCaption = get(c, 'children[0].text');
+                tableCount++;
+
+                return {
+                  ...c,
+                  children: [
+                    {
+                      ...c.children[0],
+                      text: `Table ${tableCount}: ${currentCaption}`
+                    }
+                  ]
+                };
+              })
+            };
+          })
+        }
+      };
+
+      return {
+        ...nextDoc,
+        tableCount: tableCount
+      };
+    },
+    { ...document, tableCount: 0 }
+  );
+
   const {
     key_points,
     abstract,
@@ -336,7 +430,7 @@ function JournalPdfPreview() {
     journal_discussion,
     data_availability,
     journal_acknowledgements
-  } = document;
+  } = sections;
 
   const ContentView = useMemo(() => {
     const safeReadContext = {

--- a/app/assets/scripts/components/documents/journal-pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/journal-pdf-preview/index.js
@@ -23,7 +23,7 @@ import {
   formatReference,
   sortReferences
 } from '../../../utils/references';
-import get from 'lodash.get';
+import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
 
 const ReferencesList = styled.ol`
   && {
@@ -311,99 +311,6 @@ function JournalPdfPreview() {
 
   const { keywords, document, contacts_link } = atbd;
 
-  // Section id list in the order they should appear in the document
-  const documentSectionIds = [
-    'key_points',
-    'abstract',
-    'plain_summary',
-    'publication_references',
-    'version_description',
-    'introduction',
-    'historical_perspective',
-    'additional_information',
-    'scientific_theory',
-    'scientific_theory_assumptions',
-    'mathematical_theory',
-    'mathematical_theory_assumptions',
-    'algorithm_input_variables',
-    'algorithm_output_variables',
-    'algorithm_usage_constraints',
-    'performance_assessment_validation_errors',
-    'performance_assessment_validation_methods',
-    'performance_assessment_validation_uncertainties',
-    'algorithm_implementations',
-    'data_access_input_data',
-    'data_access_output_data',
-    'data_access_related_urls',
-    'journal_discussion',
-    'data_availability',
-    'journal_acknowledgements'
-  ];
-
-  // Process sections to add table numbers to captions
-  const sections = documentSectionIds.reduce(
-    (doc, sectionId) => {
-      const section = doc[sectionId];
-
-      // Ensure the section exists
-      if (!section) return doc;
-
-      // If the section has no children, return the section as is
-      if (!section.children) {
-        return {
-          ...doc,
-          [sectionId]: section
-        };
-      }
-
-      // Init table count for this section
-      let tableCount = doc.tableCount;
-
-      const nextDoc = {
-        ...doc,
-        [sectionId]: {
-          ...section,
-          children: section.children.map((child) => {
-            // Ignore non-table blocks
-            if (child.type !== TABLE_BLOCK) {
-              return child;
-            }
-
-            // Reverse the table rows to make caption appear first
-            // and add the table number to the caption
-            return {
-              ...child,
-              children: child.children.reverse().map((c) => {
-                if (c.type !== 'caption') {
-                  return c;
-                }
-
-                const currentCaption = get(c, 'children[0].text');
-                tableCount++;
-
-                return {
-                  ...c,
-                  children: [
-                    {
-                      ...c.children[0],
-                      text: `Table ${tableCount}: ${currentCaption}`
-                    }
-                  ]
-                };
-              })
-            };
-          })
-        }
-      };
-
-      return {
-        ...nextDoc,
-        tableCount: tableCount
-      };
-    },
-    { ...document, tableCount: 0 }
-  );
-
   const {
     key_points,
     abstract,
@@ -430,7 +337,7 @@ function JournalPdfPreview() {
     journal_discussion,
     data_availability,
     journal_acknowledgements
-  } = sections;
+  } = formatDocumentTableCaptions(document);
 
   const ContentView = useMemo(() => {
     const safeReadContext = {

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -28,6 +28,7 @@ import { isJournalPublicationIntended } from '../status';
 import serializeSlateToString from '../../slate/serialize-to-string';
 import { useContextualAbility } from '../../../a11n';
 import { isDefined, isTruthyString } from '../../../utils/common';
+import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
 
 const PDFPreview = styled.iframe`
   width: 100%;
@@ -1418,7 +1419,6 @@ export function getAtbdContentSections(pdfMode = false) {
 export default function DocumentBody(props) {
   const { atbd, disableScrollManagement } = props;
   const document = atbd.document;
-
   // Scroll to an existing hash when the component mounts.
   useScrollToHashOnMount(disableScrollManagement);
   // Setup the listener to change active links.
@@ -1456,7 +1456,7 @@ export default function DocumentBody(props) {
   );
 
   return renderElements(getAtbdContentSections(atbd.document_type === 'PDF'), {
-    document,
+    document: formatDocumentTableCaptions(document),
     referencesUseIndex,
     referenceList,
     atbd,

--- a/app/assets/scripts/components/slate/plugins/caption/caption.js
+++ b/app/assets/scripts/components/slate/plugins/caption/caption.js
@@ -10,7 +10,7 @@ import { IMAGE_BLOCK, TABLE_BLOCK } from '../constants';
 const CaptionElement = styled.figcaption`
   font-size: 0.875rem;
   line-height: 1.25rem;
-  text-align: center;
+  text-align: left;
   position: relative;
 `;
 

--- a/app/assets/scripts/utils/format-table-captions.js
+++ b/app/assets/scripts/utils/format-table-captions.js
@@ -1,0 +1,100 @@
+import get from 'lodash.get';
+import { TABLE_BLOCK } from '../components/slate/plugins/constants';
+
+/**
+ * Include table numbers and move captions before the table in the document.
+ */
+export function formatDocumentTableCaptions(document) {
+  // Section id list in the order they should appear in the document
+  const documentSectionIds = [
+    'key_points',
+    'abstract',
+    'plain_summary',
+    'publication_references',
+    'version_description',
+    'introduction',
+    'historical_perspective',
+    'additional_information',
+    'scientific_theory',
+    'scientific_theory_assumptions',
+    'mathematical_theory',
+    'mathematical_theory_assumptions',
+    'algorithm_input_variables',
+    'algorithm_output_variables',
+    'algorithm_usage_constraints',
+    'performance_assessment_validation_errors',
+    'performance_assessment_validation_methods',
+    'performance_assessment_validation_uncertainties',
+    'algorithm_implementations',
+    'data_access_input_data',
+    'data_access_output_data',
+    'data_access_related_urls',
+    'journal_discussion',
+    'data_availability',
+    'journal_acknowledgements'
+  ];
+
+  // Process sections to add table numbers to captions
+  return documentSectionIds.reduce(
+    (doc, sectionId) => {
+      const section = doc[sectionId];
+
+      // Ensure the section exists
+      if (!section) return doc;
+
+      // If the section has no children, return the section as is
+      if (!section.children) {
+        return {
+          ...doc,
+          [sectionId]: section
+        };
+      }
+
+      // Init table count for this section
+      let tableCount = doc.tableCount;
+
+      const nextDoc = {
+        ...doc,
+        [sectionId]: {
+          ...section,
+          children: section.children.map((child) => {
+            // Ignore non-table blocks
+            if (child.type !== TABLE_BLOCK) {
+              return child;
+            }
+
+            // Reverse the table rows to make caption appear first
+            // and add the table number to the caption
+            return {
+              ...child,
+              children: child.children.reverse().map((c) => {
+                if (c.type !== 'caption') {
+                  return c;
+                }
+
+                const currentCaption = get(c, 'children[0].text');
+                tableCount++;
+
+                return {
+                  ...c,
+                  children: [
+                    {
+                      ...c.children[0],
+                      text: `Table ${tableCount}: ${currentCaption}`
+                    }
+                  ]
+                };
+              })
+            };
+          })
+        }
+      };
+
+      return {
+        ...nextDoc,
+        tableCount: tableCount
+      };
+    },
+    { ...document, tableCount: 0 }
+  );
+}


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/681.

Before generating the PDFs, apply `formatDocumentTableCaptions()` to the document in order to compute table numbers and move the caption before the table.

To test, run the app locally using the staging API and visit:

- http://localhost:9000/documents/test/v1.0/pdf-preview
- http://localhost:9000/documents/test/v1.0/journal-pdf-preview

Or create a new document with tables in different sections.