### PR TITLE
Fix links

### DIFF
--- a/app/assets/scripts/components/slate/plugins/link/index.js
+++ b/app/assets/scripts/components/slate/plugins/link/index.js
@@ -122,6 +122,19 @@ export const LinkPlugin = {
   onUse: onLinkUse
 };
 
+function setHttp(link) {
+  if (!link) {
+    return link;
+  }
+
+  let newLink = link;
+  if (link.search(/^http[s]?:\/\//) == -1) {
+    newLink = `http://${link}`;
+  }
+
+  return newLink;
+}
+
 export const onLinkEditorAction = (editor, action, payload) => {
   switch (action) {
     case 'cancel':
@@ -133,7 +146,7 @@ export const onLinkEditorAction = (editor, action, payload) => {
         // Reselect value.
         Transforms.select(editor, editor.linkEditor.getData().selection);
         // Upsert the link.
-        upsertLinkAtSelection(editor, payload.value, { wrap: true });
+        upsertLinkAtSelection(editor, setHttp(payload.value), { wrap: true });
         // Refocus the editor.
         ReactEditor.focus(editor);
         // Reset the link editor to hide it.

--- a/app/assets/scripts/components/slate/plugins/link/index.js
+++ b/app/assets/scripts/components/slate/plugins/link/index.js
@@ -122,14 +122,20 @@ export const LinkPlugin = {
   onUse: onLinkUse
 };
 
+/**
+ * Set the http protocol if it is missing.
+ * @param {String} link The link to check.
+ * @returns {String} The link with http protocol.
+ */
 function setHttp(link) {
   if (!link) {
     return link;
   }
 
   let newLink = link;
-  if (link.search(/^http[s]?:\/\//) == -1) {
-    newLink = `http://${link}`;
+
+  if (!link.startsWith('http://') && !link.startsWith('https://')) {
+    newLink = `https://${link}`;
   }
 
   return newLink;


### PR DESCRIPTION
Fix #554. Prefix `https://` to URLs provided by the user in edit mode if they don't contain a protocol.

cc @wildintellect @kamicut @sunu 