### PR TITLE
Fix equations and images captions in document PDF preview

### DIFF
--- a/app/assets/scripts/components/documents/journal-pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/journal-pdf-preview/index.js
@@ -23,7 +23,7 @@ import {
   formatReference,
   sortReferences
 } from '../../../utils/references';
-import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
+import { applyNumberCaptionsToDocument } from '../../../utils/apply-number-captions-to-document';
 
 const ReferencesList = styled.ol`
   && {
@@ -344,7 +344,7 @@ function JournalPdfPreview() {
     journal_discussion,
     data_availability,
     journal_acknowledgements
-  } = formatDocumentTableCaptions(document);
+  } = applyNumberCaptionsToDocument(document);
 
   const ContentView = useMemo(() => {
     const safeReadContext = {

--- a/app/assets/scripts/components/documents/pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/pdf-preview/index.js
@@ -9,7 +9,7 @@ import DocumentBody from '../single-view/document-body';
 import DocumentTitle from '../single-view/document-title';
 import { DocumentProse } from '../single-view/document-content';
 import { ScrollAnchorProvider } from '../single-view/scroll-manager';
-import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
+import { applyNumberCaptionsToDocument } from '../../../utils/apply-number-captions-to-document';
 
 const TocHeader = styled.h1`
   border-bottom: 3px solid #000;
@@ -240,7 +240,7 @@ function PdfPreview() {
     }
 
     if (atbd.status === 'succeeded') {
-      setDocument(formatDocumentTableCaptions(atbd.data.document));
+      setDocument(applyNumberCaptionsToDocument(atbd.data.document));
       waitForImages();
     }
   }, [atbd.status]);

--- a/app/assets/scripts/components/documents/pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/pdf-preview/index.js
@@ -205,15 +205,6 @@ function generateTocAndHeadingNumbering(content) {
   // Starting from h2
   generateHeading(2, tocElement, content, undefined);
 
-  const imageCaptions = content.querySelectorAll(
-    '.slate-image-block figcaption'
-  );
-  Array.from(imageCaptions).forEach((caption, i) => {
-    const captionPrefix = document.createElement('span');
-    captionPrefix.innerText = `Figure ${i + 1}: `;
-    caption.prepend(captionPrefix);
-  });
-
   const equationNumbers = content.querySelectorAll(
     '.slate-equation-element .equation-number'
   );

--- a/app/assets/scripts/components/documents/pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/pdf-preview/index.js
@@ -204,10 +204,19 @@ function generateTocAndHeadingNumbering(content) {
   // Starting from h2
   generateHeading(2, tocElement, content, undefined);
 
-  const captions = content.querySelectorAll('.slate-image-block figcaption');
-  Array.from(captions).forEach((caption, i) => {
+  const imageCaptions = content.querySelectorAll(
+    '.slate-image-block figcaption'
+  );
+  Array.from(imageCaptions).forEach((caption, i) => {
     const captionPrefix = document.createElement('span');
     captionPrefix.innerText = `Figure ${i + 1}: `;
+    caption.prepend(captionPrefix);
+  });
+
+  const tableCaptions = content.querySelectorAll('.slate-table + figcaption');
+  Array.from(tableCaptions).forEach((caption, i) => {
+    const captionPrefix = document.createElement('span');
+    captionPrefix.innerText = `Table ${i + 1}: `;
     caption.prepend(captionPrefix);
   });
 

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -28,7 +28,6 @@ import { isJournalPublicationIntended } from '../status';
 import serializeSlateToString from '../../slate/serialize-to-string';
 import { useContextualAbility } from '../../../a11n';
 import { isDefined, isTruthyString } from '../../../utils/common';
-import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
 
 const PDFPreview = styled.iframe`
   width: 100%;
@@ -1456,7 +1455,7 @@ export default function DocumentBody(props) {
   );
 
   return renderElements(getAtbdContentSections(atbd.document_type === 'PDF'), {
-    document: formatDocumentTableCaptions(document),
+    document,
     referencesUseIndex,
     referenceList,
     atbd,

--- a/app/assets/scripts/utils/apply-number-captions-to-document.js
+++ b/app/assets/scripts/utils/apply-number-captions-to-document.js
@@ -7,7 +7,7 @@ import {
 /**
  * Include table numbers and move captions before the table in the document.
  */
-export function formatDocumentTableCaptions(document) {
+export function applyNumberCaptionsToDocument(document) {
   // Section id list in the order they should appear in the document
   const documentSectionIds = [
     'key_points',

--- a/app/assets/scripts/utils/format-table-captions.js
+++ b/app/assets/scripts/utils/format-table-captions.js
@@ -1,5 +1,8 @@
 import get from 'lodash.get';
-import { TABLE_BLOCK } from '../components/slate/plugins/constants';
+import {
+  IMAGE_BLOCK,
+  TABLE_BLOCK
+} from '../components/slate/plugins/constants';
 
 /**
  * Include table numbers and move captions before the table in the document.
@@ -34,6 +37,11 @@ export function formatDocumentTableCaptions(document) {
     'journal_acknowledgements'
   ];
 
+  let elementCount = {
+    [TABLE_BLOCK]: 0,
+    [IMAGE_BLOCK]: 0
+  };
+
   // Process sections to add table numbers to captions
   return documentSectionIds.reduce(
     (doc, sectionId) => {
@@ -50,51 +58,52 @@ export function formatDocumentTableCaptions(document) {
         };
       }
 
-      // Init table count for this section
-      let tableCount = doc.tableCount;
-
       const nextDoc = {
         ...doc,
         [sectionId]: {
           ...section,
           children: section.children.map((child) => {
-            // Ignore non-table blocks
-            if (child.type !== TABLE_BLOCK) {
-              return child;
+            // Transform the table and image blocks
+            if (child.type === TABLE_BLOCK || child.type === IMAGE_BLOCK) {
+              elementCount[child.type] += 1;
+
+              const captionPrefix = `${
+                child.type === TABLE_BLOCK ? 'Table' : 'Figure'
+              } ${elementCount[child.type]}: `;
+
+              // Reverse the table rows to make caption appear first
+              // and add the table number to the caption
+              return {
+                ...child,
+                children: child.children.reverse().map((c) => {
+                  if (c.type !== 'caption') {
+                    return c;
+                  }
+
+                  const currentCaption = get(c, 'children[0].text');
+
+                  return {
+                    ...c,
+                    children: [
+                      {
+                        ...c.children[0],
+                        text: `${captionPrefix}${currentCaption}`
+                      }
+                    ]
+                  };
+                })
+              };
             }
 
-            // Reverse the table rows to make caption appear first
-            // and add the table number to the caption
-            return {
-              ...child,
-              children: child.children.reverse().map((c) => {
-                if (c.type !== 'caption') {
-                  return c;
-                }
-
-                const currentCaption = get(c, 'children[0].text');
-                tableCount++;
-
-                return {
-                  ...c,
-                  children: [
-                    {
-                      ...c.children[0],
-                      text: `Table ${tableCount}: ${currentCaption}`
-                    }
-                  ]
-                };
-              })
-            };
+            return child;
           })
         }
       };
 
       return {
-        ...nextDoc,
-        tableCount: tableCount
+        ...nextDoc
       };
     },
-    { ...document, tableCount: 0 }
+    { ...document }
   );
 }


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/549 (reported [here](https://github.com/NASA-IMPACT/nasa-apt/issues/681#issuecomment-1753109122)) where the captions and number for images and equations disappeared in the document PDF preview. 

Please note this PR only reinstates the preexisting number in document PDF preview. The following issues are still present:

- Document preview: image and table captions positioned at the bottom
- Journal preview: images caption positioned at the bottom

I suggest we handle those separately as they look more involved.

To test, open a document in document preview mode and confirm numbers are present for images, equations, and tables. Example:

- http://localhost:9000/documents/links/v1.0/pdf-preview

cc @wrynearson @sunu @kamicut 