### PR TITLE
Add algorithm variables to the journal pdf

### DIFF
--- a/app/assets/scripts/components/documents/journal-pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/journal-pdf-preview/index.js
@@ -24,6 +24,7 @@ import {
   sortReferences
 } from '../../../utils/references';
 import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
+import { VariableItem } from '../single-view/document-body';
 
 const ReferencesList = styled.ol`
   && {
@@ -213,6 +214,51 @@ ImplementationDataList.propTypes = {
     T.shape({
       url: T.string,
       description: T.string
+    })
+  )
+};
+
+function VariablesList({ list }) {
+  if (!list || list.length === 0) {
+    return EMPTY_CONTENT_MESSAGE;
+  }
+
+  return (
+    <DataListContainer>
+      {list?.map((variable, i) => (
+        <VariableItem
+          key={`variable-${i + 1}`}
+          variable={variable}
+          element={{ id: `variable-${i}`, label: `Variable #${i + 1}` }}
+        />
+      ))}
+    </DataListContainer>
+  );
+}
+
+VariablesList.propTypes = {
+  list: T.arrayOf(T.object)
+};
+
+const pChildType = T.shape({
+  type: T.string.isRequired,
+  children: T.arrayOf(
+    T.shape({
+      text: T.string.isRequired
+    })
+  ).isRequired
+});
+
+const variableNodePropType = T.shape({
+  children: T.arrayOf(pChildType).isRequired
+});
+
+VariablesList.propTypes = {
+  list: T.arrayOf(
+    T.shape({
+      name: variableNodePropType.isRequired,
+      long_name: variableNodePropType.isRequired,
+      unit: variableNodePropType.isRequired
     })
   )
 };
@@ -534,10 +580,9 @@ function JournalPdfPreview() {
   );
   const mathematicalTheoryVisible =
     hasContent(mathematical_theory) || mathematicalTheoryAssumptionsVisible;
-  const algorithmInputVariablesVisible = hasContent(algorithm_input_variables);
-  const algorithmOutputVariablesVisible = hasContent(
-    algorithm_output_variables
-  );
+  const algorithmInputVariablesVisible = algorithm_input_variables?.length > 0;
+  const algorithmOutputVariablesVisible =
+    algorithm_output_variables?.length > 0;
   const algorithmDescriptionVisible =
     scientificTheoryVisible ||
     mathematicalTheoryVisible ||
@@ -696,7 +741,7 @@ function JournalPdfPreview() {
                   id='algorithm_input_variables'
                   title='Algorithm Input Variables'
                 >
-                  <ContentView value={algorithm_input_variables} />
+                  <VariablesList list={algorithm_input_variables} />
                 </Section>
               )}
               {algorithmOutputVariablesVisible && (
@@ -704,7 +749,7 @@ function JournalPdfPreview() {
                   id='algorithm_output_variables'
                   title='Algorithm Output Variables'
                 >
-                  <ContentView value={algorithm_output_variables} />
+                  <VariablesList list={algorithm_output_variables} />
                 </Section>
               )}
             </Section>

--- a/app/assets/scripts/components/documents/journal-pdf-preview/index.js
+++ b/app/assets/scripts/components/documents/journal-pdf-preview/index.js
@@ -25,6 +25,7 @@ import {
 } from '../../../utils/references';
 import { formatDocumentTableCaptions } from '../../../utils/format-table-captions';
 import { VariableItem } from '../single-view/document-body';
+import { variableNodeType } from '../../../types';
 
 const ReferencesList = styled.ol`
   && {
@@ -237,30 +238,7 @@ function VariablesList({ list }) {
 }
 
 VariablesList.propTypes = {
-  list: T.arrayOf(T.object)
-};
-
-const pChildType = T.shape({
-  type: T.string.isRequired,
-  children: T.arrayOf(
-    T.shape({
-      text: T.string.isRequired
-    })
-  ).isRequired
-});
-
-const variableNodePropType = T.shape({
-  children: T.arrayOf(pChildType).isRequired
-});
-
-VariablesList.propTypes = {
-  list: T.arrayOf(
-    T.shape({
-      name: variableNodePropType.isRequired,
-      long_name: variableNodePropType.isRequired,
-      unit: variableNodePropType.isRequired
-    })
-  )
+  list: T.arrayOf(variableNodeType)
 };
 
 function ContactOutput(props) {

--- a/app/assets/scripts/components/documents/single-view/document-body.js
+++ b/app/assets/scripts/components/documents/single-view/document-body.js
@@ -216,7 +216,7 @@ const DataAccessItem = ({ id, label, url, description }) => (
   </AtbdSubSection>
 );
 
-const VariableItem = ({ element, variable }) => (
+export const VariableItem = ({ element, variable }) => (
   <React.Fragment>
     <h4 id={element.id} data-scroll='target'>
       {element.label}
@@ -301,7 +301,7 @@ const ContactItem = ({ id, label, contact, roles, affiliations }) => (
   </AtbdSubSection>
 );
 
-const EmptySection = ({ className }) => (
+export const EmptySection = ({ className }) => (
   <p className={className}>No content available.</p>
 );
 

--- a/app/assets/scripts/types.js
+++ b/app/assets/scripts/types.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+
+// Basic text child type
+const textChildType = PropTypes.shape({
+  text: PropTypes.string.isRequired
+});
+
+// Type for a paragraph element with children
+const pChildType = PropTypes.shape({
+  type: PropTypes.string.isRequired,
+  children: PropTypes.arrayOf(textChildType).isRequired
+});
+
+// Type for a variable node with children
+const variableNodePropType = PropTypes.shape({
+  children: PropTypes.arrayOf(pChildType).isRequired
+});
+
+// Type for a variable item in the list
+export const variableNodeType = PropTypes.shape({
+  name: variableNodePropType.isRequired,
+  long_name: variableNodePropType.isRequired,
+  unit: variableNodePropType.isRequired
+});


### PR DESCRIPTION
This adds missing sections (3.3 and 3.4) to journal PDF, as reported [in this comment](https://github.com/NASA-IMPACT/nasa-apt-frontend/issues/421#issuecomment-1758011668).

Additionally, I've initiated a types.js file to house common type definitions, which I find beneficial for identifying data structures throughout the app.

@kamicut @sunu ready for review.