### PR TITLE
Enhance collected metrics (atdb edits, template download)

### DIFF
--- a/app/assets/scripts/components/documents/document-delete-process.js
+++ b/app/assets/scripts/components/documents/document-delete-process.js
@@ -1,5 +1,6 @@
 import { confirmDeleteDocumentVersion } from '../common/confirmation-prompt';
 import toasts from '../common/toasts';
+import ReactGA from 'react-ga4';
 
 /**
  * Convenience method to delete an atbd version and show a toast notification.
@@ -24,6 +25,7 @@ export async function documentDeleteVersionConfirmAndToast({
     if (result.error) {
       toasts.error(`An error occurred: ${result.error.message}`);
     } else {
+      ReactGA.event('atbd_version_deleted');
       toasts.success('Document version successfully deleted');
       history.push('/dashboard');
     }

--- a/app/assets/scripts/components/documents/single-edit/use-document-create.js
+++ b/app/assets/scripts/components/documents/single-edit/use-document-create.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useHistory } from 'react-router';
+import ReactGA from 'react-ga4';
 
 import { useAtbds } from '../../../context/atbds-list';
 import { documentEdit } from '../../../utils/url-creator';
@@ -33,6 +34,10 @@ export function useDocumentCreate(title, alias, isPdfType) {
         processToast.error(`An error occurred: ${result.error.message}`);
       }
     } else {
+      ReactGA.event('atbd_created', {
+        type: isPdfType ? 'pdf' : 'regular'
+      });
+
       processToast.success('Document successfully created');
       // To trigger the modals to open from other pages, we use the history
       // state as the user is sent from one page to another. See explanation

--- a/app/assets/scripts/components/documents/single-edit/use-submit.js
+++ b/app/assets/scripts/components/documents/single-edit/use-submit.js
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useHistory } from 'react-router';
+import ReactGA from 'react-ga4';
 
 import { documentEdit } from '../../../utils/url-creator';
 import { createProcessToast } from '../../common/toasts';
@@ -22,6 +23,7 @@ export function useSubmitForMetaAndVersionData(updateAtbd, atbd, step) {
       if (result.error) {
         processToast.error(`An error occurred: ${result.error.message}`);
       } else {
+        ReactGA.event('atbd_updated');
         resetForm({ values });
         processToast.success('Changes saved');
         // Update the path in case the alias changed.
@@ -81,6 +83,7 @@ export function useSubmitForVersionData(updateAtbd, atbd, hook) {
       if (result.error) {
         processToast.error(`An error occurred: ${result.error.message}`);
       } else {
+        ReactGA.event('atbd_updated');
         formBag.resetForm({ values });
         processToast.success('Changes saved');
 
@@ -300,6 +303,7 @@ export function useSubmitForAtbdContacts({
             `An error occurred: ${result.error.message}. Please try again`
           );
         } else {
+          ReactGA.event('atbd_updated');
           resetForm({
             values: {
               ...values,

--- a/app/assets/scripts/components/new-atbd/index.js
+++ b/app/assets/scripts/components/new-atbd/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { themeVal, glsp } from '@devseed-ui/theme-provider';
 import { Button } from '@devseed-ui/button';
+import ReactGA from 'react-ga4';
 
 import {
   FaFileAlt,
@@ -232,6 +233,11 @@ function NewAtbd() {
                 href='https://docs.google.com/document/d/1T4q56qZrRN5L6MGXA1UJLMgDgS-Fde9Fo4R4bwVQDF8/edit?usp=sharing'
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={() => {
+                  ReactGA.event('atbd_template_download', {
+                    template_format: 'Google Docs'
+                  });
+                }}
               >
                 <span>
                   <FaFileAlt />
@@ -242,6 +248,11 @@ function NewAtbd() {
                 href='https://docs.google.com/document/d/1Jh3htOiivNIG_ZqhbN5nEK1TAVB6BjRY/edit?usp=share_link&ouid=102031143611308171378&rtpof=true&sd=true'
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={() => {
+                  ReactGA.event('atbd_template_download', {
+                    template_format: 'Microsoft Word'
+                  });
+                }}
               >
                 <span>
                   <FaFileWord />
@@ -251,7 +262,12 @@ function NewAtbd() {
               <TemplateLink
                 href='https://drive.google.com/file/d/1AusZOxIpkBiA0QJAB3AtSXSBUU5tWwlJ/view?usp=share_link'
                 target='_blank'
-                rel='noopener'
+                rel='noopener noreferrer'
+                onClick={() => {
+                  ReactGA.event('atbd_template_download', {
+                    template_format: 'Latex'
+                  });
+                }}
               >
                 <span>
                   <SiLatex />


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/807.

Changes:

- Add custom events to successful ATBD creation, update and deletion
- Add custom event to ATBD template downloads by format

How to test:

- Copy staging tracking code `config/local.js`
- Run the app locally
- Create documents, both regular and PDF upload
- Update and delete documents
- Go to GA dashboard
- Click "Reports" and "Realtime" in the left vertical bar
- Your events should be listed in `Event count by Event name` panel
- Click `atbd_created` event, it should include a property named `type` equal `pdf`and one equal to `regular`
- Click `atbd_template_download` it should include a property called `template_format` with the number of times each template format was downloaded

Please note the "Lifecycle" panel will not change right way as the "Realtime" does. It can take up to 24-48 hours to display the events. I believe the events introduced, along with the preexisting ones (session_start, user_engagement), should be sufficient to generate the required metrics.

@wrynearson ready for review.

