### PR TITLE
Move the template format to the event name (Google Analytics)

### DIFF
--- a/app/assets/scripts/components/new-atbd/index.js
+++ b/app/assets/scripts/components/new-atbd/index.js
@@ -234,9 +234,7 @@ function NewAtbd() {
                 target='_blank'
                 rel='noopener noreferrer'
                 onClick={() => {
-                  ReactGA.event('atbd_template_download', {
-                    template_format: 'Google Docs'
-                  });
+                  ReactGA.event('atbd_template_download_google_docs');
                 }}
               >
                 <span>
@@ -249,9 +247,7 @@ function NewAtbd() {
                 target='_blank'
                 rel='noopener noreferrer'
                 onClick={() => {
-                  ReactGA.event('atbd_template_download', {
-                    template_format: 'Microsoft Word'
-                  });
+                  ReactGA.event('atbd_template_download_ms_word');
                 }}
               >
                 <span>
@@ -264,9 +260,7 @@ function NewAtbd() {
                 target='_blank'
                 rel='noopener noreferrer'
                 onClick={() => {
-                  ReactGA.event('atbd_template_download', {
-                    template_format: 'Latex'
-                  });
+                  ReactGA.event('atbd_template_download_latex');
                 }}
               >
                 <span>


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/nasa-apt/issues/807.

In https://github.com/NASA-IMPACT/nasa-apt-frontend/pull/563 we added custom events for tracking template downloads by format, but it seems the event parameter `template_format` is not persisted after some time in the GA dashboard.

In this PR I moved the format to the event name, which should allow tracking download events by format older than 30 mins.

How to test:

- Replace config/local.js with the content of config/staging.js
- Run the app
- Visit http://localhost:9000/new-atbd and download each of the available formats
- Visit GA dashboard
- Go to Reports -> Realtime
- Box 'Event count' by 'Event name' should list the new event names:
  - `atbd_template_download_google_docs`
  - `atbd_template_download_ms_word`
  - `atbd_template_download_latex`

The other reports won't show the events right away because GA doesn't aggregate events for the current day. They should appear after they are older that 1 day.

@wrynearson this is ready for review.