### PR TITLE
Fix auth messages in 'create atbd' pages

### DIFF
--- a/app/assets/scripts/a11n/forbidden.js
+++ b/app/assets/scripts/a11n/forbidden.js
@@ -15,7 +15,7 @@ import { Link } from '../styles/clean/link';
 import { useUser } from '../context/user';
 
 function Forbidden() {
-  const user = useUser();
+  const { isLogged } = useUser();
 
   return (
     <App pageTitle='Forbidden'>
@@ -29,7 +29,7 @@ function Forbidden() {
           <ContentBlock>
             <Prose>
               <p>You don&apos;t have access to this page!</p>
-              {user.isLogged ? (
+              {isLogged ? (
                 <p>
                   If you think this is a mistake let us know via{' '}
                   <a href='mailto:' title='Send us an email'>

--- a/app/assets/scripts/components/new-atbd/index.js
+++ b/app/assets/scripts/components/new-atbd/index.js
@@ -164,14 +164,14 @@ const FeedbackLink = (props) => (
 
 function NewAtbd() {
   const [showMoreInfo, setShowMoreInfo] = React.useState(false);
-  const { user } = useUser();
+  const { isLogged } = useUser();
 
   return (
     <App pageTitle='New ATBD'>
       <PageContent>
         <Header>
           <h1>ATBD Creation Choices</h1>
-          {!user.isLogged && (
+          {!isLogged && (
             <Feedback>
               <a href={getHostedAuthUiUrl('signup')}>Sign up</a> now to get
               started!


### PR DESCRIPTION
How to test: visit 'Create ATDB' page at http://localhost:9000/new-atbd, it shouldn't display 'Sign in' message if the user is logged in.

I also included the same API change in the 'Forbidden' page, but it is not clear to me how to get to desired state. 

@kamicut ready for review.