### PR TITLE
Fix document info modal citation

### DIFF
--- a/app/assets/scripts/components/documents/citation.js
+++ b/app/assets/scripts/components/documents/citation.js
@@ -6,6 +6,8 @@ import { FormHelperMessage } from '@devseed-ui/form';
 import getDocumentIdKey from './get-document-id-key';
 import { documentView } from '../../utils/url-creator';
 import { formatAuthors } from '../../utils/references';
+import config from '../../config';
+const { baseUrl } = config;
 
 // Symbol to define that the description should come from the strings file.
 export const formStringSymbol = Symbol.for('form string');
@@ -115,7 +117,8 @@ function getCitationDocUrl(atbd) {
     return citation.online_resource;
   }
 
-  return `${window.location.origin}${documentView(atbd)}`;
+  const publicUrl = baseUrl || window.location.origin;
+  return `${publicUrl}${documentView(atbd)}`;
 }
 
 function getCitationDocVersion(atbd) {
@@ -164,9 +167,11 @@ export function createStringCitation(atbd) {
   const authors = formatAuthors(atbd.citation.creators, 'citation');
   const title = atbd.title;
   const url = getCitationDocUrl(atbd);
+  const doi = atbd.doi;
+  let docRef = doi ? doi : url;
   const publisher = atbd.citation.publisher;
   const returnStr = `${authors}. (${year}). ${title}, ${getCitationDocVersion(
     atbd
-  )}. ${publisher}. (${url})`;
+  )}. ${publisher}. (${docRef})`;
   return returnStr;
 }

--- a/app/assets/scripts/components/documents/citation.js
+++ b/app/assets/scripts/components/documents/citation.js
@@ -19,8 +19,8 @@ export const citationFields = [
     description: formStringSymbol,
     helper: (
       <FormHelperMessage>
-        Separate values with <em>and</em> (e.g., John Doe <em>and</em> Jane
-        Doe).
+        Separate values with <em>and</em> (e.g. Doe, John <em>and</em> Doe,
+        Jane).
       </FormHelperMessage>
     )
   },
@@ -30,8 +30,8 @@ export const citationFields = [
     description: formStringSymbol,
     helper: (
       <FormHelperMessage>
-        Separate values with <em>and</em> (e.g., John Doe <em>and</em> Jane
-        Doe).
+        Separate values with <em>and</em> (e.g. Doe, John <em>and</em> Doe,
+        Jane).
       </FormHelperMessage>
     )
   },

--- a/app/assets/scripts/components/documents/citation.js
+++ b/app/assets/scripts/components/documents/citation.js
@@ -5,6 +5,7 @@ import { FormHelperMessage } from '@devseed-ui/form';
 
 import getDocumentIdKey from './get-document-id-key';
 import { documentView } from '../../utils/url-creator';
+import { formatAuthors } from '../../utils/references';
 
 // Symbol to define that the description should come from the strings file.
 export const formStringSymbol = Symbol.for('form string');
@@ -151,26 +152,21 @@ export function createBibtexCitation(atbd) {
 }
 
 /**
- * Creates a comma separated citation from the given atbd.
+ * Creates a citation from the given atbd.
+ * Format is:
+ * Authors. (Publication Date). Title, version. Publisher. (DOC URL or DOI).
  *
  * @param {object} atbd The document for which to create a citation
  * @returns string
  */
 export function createStringCitation(atbd) {
-  const { title, citation } = atbd;
-  const { dateStr } = getCitationPublicationDate(atbd);
-  const citationVersion = getCitationDocVersion(atbd);
+  const { year } = getCitationPublicationDate(atbd);
+  const authors = formatAuthors(atbd.citation.creators, 'citation');
+  const title = atbd.title;
   const url = getCitationDocUrl(atbd);
-
-  return [
-    title,
-    citation.creators,
-    citation.editors,
-    citation.publisher,
-    dateStr,
-    citationVersion,
-    url
-  ]
-    .filter(Boolean)
-    .join(', ');
+  const publisher = atbd.citation.publisher;
+  const returnStr = `${authors}. (${year}). ${title}, ${getCitationDocVersion(
+    atbd
+  )}. ${publisher}. (${url})`;
+  return returnStr;
 }

--- a/app/assets/scripts/utils/references.js
+++ b/app/assets/scripts/utils/references.js
@@ -64,7 +64,7 @@ export const getReferenceEmptyValue = (base = {}) => {
  * @param {String} authors - A list of authors separated by 'and'
  * @returns A string of authors in AGU style
  */
-function formatAuthors(authors, type = 'reference') {
+export function formatAuthors(authors, type = 'reference') {
   if (!authors || authors.length === 0) return '';
   const authorsList = authors.split(' and ');
 


### PR DESCRIPTION
The document info modal uses the `identifying information` step and formats the author, publisher and DOI into a citation.

Upstream ticket: https://github.com/NASA-IMPACT/nasa-apt/issues/825

Here's what's fixed:

- [x] Correctly format authors
- [x] Proper formatting for DOI / Website